### PR TITLE
WIP: Support batch-reading for data-types with chunksize parameter

### DIFF
--- a/mlem/api/commands.py
+++ b/mlem/api/commands.py
@@ -58,6 +58,7 @@ def apply(
     output: str = None,
     link: bool = None,
     external: bool = None,
+    batch: Optional[int] = None,
 ) -> Optional[Any]:
     """Apply provided model against provided data
 
@@ -85,7 +86,7 @@ def apply(
         resolved_method = PREDICT_METHOD_NAME
     echo(EMOJI_APPLY + f"Applying `{resolved_method}` method...")
     res = [
-        w.call_method(resolved_method, get_dataset_value(part))
+        w.call_method(resolved_method, get_dataset_value(part, batch))
         for part in data
     ]
     if output is None:
@@ -412,6 +413,7 @@ def import_object(
     target_repo: Optional[str] = None,
     target_fs: Optional[AbstractFileSystem] = None,
     type_: Optional[str] = None,
+    batch: Optional[int] = None,
     copy_data: bool = True,
     external: bool = None,
     link: bool = None,
@@ -426,7 +428,7 @@ def import_object(
         if type_ not in ImportHook.__type_map__:
             raise ValueError(f"Unknown import type {type_}")
         meta = ImportHook.__type_map__[type_].process(
-            loc, copy_data=copy_data, modifier=modifier
+            loc, copy_data=copy_data, modifier=modifier, batch=batch
         )
     else:
         meta = ImportAnalyzer.analyze(loc, copy_data=copy_data)

--- a/mlem/api/utils.py
+++ b/mlem/api/utils.py
@@ -7,14 +7,17 @@ from mlem.core.metadata import load, load_meta
 from mlem.core.objects import DatasetMeta, MlemMeta, ModelMeta
 
 
-def get_dataset_value(dataset: Any) -> Any:
+def get_dataset_value(dataset: Any, batch: Optional[int] = None) -> Any:
     if isinstance(dataset, str):
         return load(dataset)
     if isinstance(dataset, DatasetMeta):
         # TODO: https://github.com/iterative/mlem/issues/29
         #  fix discrepancies between model and data meta objects
         if not hasattr(dataset.dataset, "data"):
-            dataset.load_value()
+            if batch:
+                dataset.load_batch_value(batch)
+            else:
+                dataset.load_value()
         return dataset.data
 
     # TODO: https://github.com/iterative/mlem/issues/29

--- a/mlem/cli/apply.py
+++ b/mlem/cli/apply.py
@@ -60,6 +60,9 @@ def apply(
         # TODO: change ImportHook to MlemObject to support ext machinery
         help=f"Specify how to read data file for import. Available types: {list_implementations(ImportHook)}",
     ),
+    batch: Optional[int] = Option(
+        None, "-b", "--batch", help="Batch size for reading data in batches."
+    ),
     link: bool = option_link,
     external: bool = option_external,
     json: bool = option_json,
@@ -83,7 +86,11 @@ def apply(
     with set_echo(None if json else ...):
         if import_:
             dataset = import_object(
-                data, repo=data_repo, rev=data_rev, type_=import_type
+                data,
+                repo=data_repo,
+                rev=data_rev,
+                type_=import_type,
+                batch=batch,
             )
         else:
             dataset = load_meta(
@@ -92,6 +99,7 @@ def apply(
                 data_rev,
                 load_value=True,
                 force_type=DatasetMeta,
+                batch=batch,
             )
         meta = load_meta(model, repo, rev, force_type=ModelMeta)
 
@@ -102,6 +110,7 @@ def apply(
             output=output,
             link=link,
             external=external,
+            batch=batch,
         )
     if output is None and json:
         print(

--- a/mlem/contrib/numpy.py
+++ b/mlem/contrib/numpy.py
@@ -1,5 +1,5 @@
 from types import ModuleType
-from typing import Any, ClassVar, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, ClassVar, List, Optional, Tuple, Type, Union
 
 import numpy as np
 from pydantic import BaseModel, conlist, create_model
@@ -172,11 +172,7 @@ class NumpyArrayWriter(DatasetWriter):
     type: ClassVar[str] = "numpy"
 
     def write(
-        self,
-        dataset: DatasetType,
-        storage: Storage,
-        path: str,
-        writer_fmt_args: Optional[Dict[str, Any]] = None,
+        self, dataset: DatasetType, storage: Storage, path: str
     ) -> Tuple[DatasetReader, Artifacts]:
         with storage.open(path) as (f, art):
             np.savez_compressed(f, **{DATA_KEY: dataset.data})

--- a/mlem/contrib/numpy.py
+++ b/mlem/contrib/numpy.py
@@ -1,5 +1,5 @@
 from types import ModuleType
-from typing import Any, ClassVar, List, Optional, Tuple, Type, Union
+from typing import Any, ClassVar, Iterator, List, Optional, Tuple, Type, Union
 
 import numpy as np
 from pydantic import BaseModel, conlist, create_model
@@ -193,5 +193,5 @@ class NumpyArrayReader(DatasetReader):
             data = np.load(f)[DATA_KEY]
         return self.dataset_type.copy().bind(data)
 
-    def read_batch(self, artifacts: Artifacts, batch: int) -> DatasetType:
+    def read_batch(self, artifacts: Artifacts, batch: int) -> Iterator:
         raise NotImplementedError

--- a/mlem/contrib/numpy.py
+++ b/mlem/contrib/numpy.py
@@ -1,5 +1,5 @@
 from types import ModuleType
-from typing import Any, ClassVar, List, Optional, Tuple, Type, Union
+from typing import Any, ClassVar, Dict, List, Optional, Tuple, Type, Union
 
 import numpy as np
 from pydantic import BaseModel, conlist, create_model
@@ -172,7 +172,11 @@ class NumpyArrayWriter(DatasetWriter):
     type: ClassVar[str] = "numpy"
 
     def write(
-        self, dataset: DatasetType, storage: Storage, path: str
+        self,
+        dataset: DatasetType,
+        storage: Storage,
+        path: str,
+        writer_fmt_args: Optional[Dict[str, Any]] = None,
     ) -> Tuple[DatasetReader, Artifacts]:
         with storage.open(path) as (f, art):
             np.savez_compressed(f, **{DATA_KEY: dataset.data})
@@ -192,3 +196,6 @@ class NumpyArrayReader(DatasetReader):
         with artifacts[DatasetWriter.art_name].open() as f:
             data = np.load(f)[DATA_KEY]
         return self.dataset_type.copy().bind(data)
+
+    def read_batch(self, artifacts: Artifacts, batch: int) -> DatasetType:
+        raise NotImplementedError

--- a/mlem/contrib/pandas.py
+++ b/mlem/contrib/pandas.py
@@ -442,7 +442,7 @@ def read_batch_csv_with_unnamed(*args, **kwargs):
     df_iterator = pd.read_csv(*args, **kwargs)
     unnamed = {}
     for i, df_chunk in enumerate(df_iterator):
-        # Instantiate Pandas DataFrame if it is the first chunk
+        # Instantiate Pandas DataFrame with columns if it is the first chunk
         if i == 0:
             df = pd.DataFrame(columns=df_chunk.columns)
             for col in df_chunk.columns:
@@ -462,7 +462,7 @@ def read_batch_reset_index(read_func: Callable, *args, **kwargs):
     df = pd.DataFrame()
     df_iterator = read_func(*args, **kwargs)
     for i, df_chunk in enumerate(df_iterator):
-        # Instantiate Pandas DataFrame if it is the first chunk
+        # Instantiate Pandas DataFrame with columns if it is the first chunk
         if i == 0:
             df = pd.DataFrame(columns=df_chunk.columns)
         df = pd.concat([df, df_chunk], ignore_index=True)

--- a/mlem/contrib/pandas.py
+++ b/mlem/contrib/pandas.py
@@ -469,6 +469,18 @@ def read_batch_json_reset_index(*args, **kwargs):
     return df
 
 
+def read_batch_stata_reset_index(*args, **kwargs):
+    df = None
+    df_iterator = pd.read_stata(*args, **kwargs)
+    for i, df_chunk in enumerate(df_iterator):
+        # Instantiate Pandas DataFrame if it is the first chunk
+        if i == 0:
+            df = pd.DataFrame(columns=df_chunk.columns)
+        df = pd.concat([df, df_chunk], ignore_index=True)
+    df = df.reset_index(drop=True)
+    return df
+
+
 def read_html(*args, **kwargs):
     # read_html returns list of dataframes
     return pd.read_html(*args, **kwargs)[0]
@@ -639,6 +651,9 @@ def update_batch_args(
             "lines": True,
             "orient": "records",
         }
+    elif type_ == "stata":
+        fmt.read_func = read_batch_stata_reset_index
+        fmt.read_args = {"chunksize": batch}
     else:
         raise UnsupportedDatasetBatchLoadingType(type_)
 

--- a/mlem/core/dataset_type.py
+++ b/mlem/core/dataset_type.py
@@ -404,6 +404,10 @@ class DatasetReader(MlemObject, ABC):
     def read(self, artifacts: Artifacts) -> DatasetType:
         raise NotImplementedError
 
+    @abstractmethod
+    def read_batch(self, artifacts: Artifacts, batch: int) -> DatasetType:
+        raise NotImplementedError
+
 
 class DatasetWriter(MlemObject):
     """"""
@@ -416,6 +420,10 @@ class DatasetWriter(MlemObject):
 
     @abstractmethod
     def write(
-        self, dataset: DatasetType, storage: Storage, path: str
+        self,
+        dataset: DatasetType,
+        storage: Storage,
+        path: str,
+        writer_fmt_args: Optional[Dict[str, Any]] = None,
     ) -> Tuple[DatasetReader, Artifacts]:
         raise NotImplementedError

--- a/mlem/core/dataset_type.py
+++ b/mlem/core/dataset_type.py
@@ -420,10 +420,6 @@ class DatasetWriter(MlemObject):
 
     @abstractmethod
     def write(
-        self,
-        dataset: DatasetType,
-        storage: Storage,
-        path: str,
-        writer_fmt_args: Optional[Dict[str, Any]] = None,
+        self, dataset: DatasetType, storage: Storage, path: str
     ) -> Tuple[DatasetReader, Artifacts]:
         raise NotImplementedError

--- a/mlem/core/dataset_type.py
+++ b/mlem/core/dataset_type.py
@@ -3,7 +3,17 @@ Base classes for working with datasets in MLEM
 """
 import builtins
 from abc import ABC, abstractmethod
-from typing import Any, ClassVar, Dict, List, Optional, Sized, Tuple, Type
+from typing import (
+    Any,
+    ClassVar,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Sized,
+    Tuple,
+    Type,
+)
 
 from pydantic import BaseModel
 from pydantic.main import create_model
@@ -405,7 +415,7 @@ class DatasetReader(MlemObject, ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def read_batch(self, artifacts: Artifacts, batch: int) -> DatasetType:
+    def read_batch(self, artifacts: Artifacts, batch: int) -> Iterator:
         raise NotImplementedError
 
 

--- a/mlem/core/errors.py
+++ b/mlem/core/errors.py
@@ -70,6 +70,25 @@ class MlemObjectNotLoadedError(ValueError, MlemError):
     """Thrown if model or dataset value is not loaded"""
 
 
+class UnsupportedDatasetBatchLoadingType(ValueError, MlemError):
+    """Thrown if batch loading of dataset with unsupported file type is called"""
+
+    _message = "Batch-loading Dataset of type '{dataset_type}' is currently not supported. Please remove batch parameter."
+
+    def __init__(
+        self,
+        dataset_type,
+    ) -> None:
+
+        self.dataset_type = dataset_type
+        self.message = self._message.format(dataset_type=dataset_type)
+        super().__init__(self.message)
+
+
+class DatasetBatchLoadingJSONError(ValueError, MlemError):
+    """Thrown if batch loading of JSON dataset is not line-delimited"""
+
+
 class WrongMethodError(ValueError, MlemError):
     """Thrown if wrong method name for model is provided"""
 

--- a/mlem/core/errors.py
+++ b/mlem/core/errors.py
@@ -85,10 +85,6 @@ class UnsupportedDatasetBatchLoadingType(ValueError, MlemError):
         super().__init__(self.message)
 
 
-class DatasetBatchLoadingJSONError(ValueError, MlemError):
-    """Thrown if batch loading of JSON dataset is not line-delimited"""
-
-
 class WrongMethodError(ValueError, MlemError):
     """Thrown if wrong method name for model is provided"""
 

--- a/mlem/core/metadata.py
+++ b/mlem/core/metadata.py
@@ -107,6 +107,7 @@ def load(
     path: str,
     repo: Optional[str] = None,
     rev: Optional[str] = None,
+    batch: Optional[int] = None,
     follow_links: bool = True,
 ) -> Any:
     """Load python object saved by MLEM
@@ -115,6 +116,7 @@ def load(
         path (str): Path to the object. Could be local path or path inside a git repo.
         repo (Optional[str], optional): URL to repo if object is located there.
         rev (Optional[str], optional): revision, could be git commit SHA, branch name or tag.
+        batch (Optional[int], optional): batch, required if performing batch-reading of Dataset.
         follow_links (bool, optional): If object we read is a MLEM link, whether to load the
             actual object link points to. Defaults to True.
 
@@ -127,6 +129,7 @@ def load(
         rev=rev,
         follow_links=follow_links,
         load_value=True,
+        batch=batch,
     )
     return meta.get_value()
 
@@ -142,6 +145,7 @@ def load_meta(
     follow_links: bool = True,
     load_value: bool = False,
     fs: Optional[AbstractFileSystem] = None,
+    batch: Optional[int] = None,
     *,
     force_type: Literal[None] = None,
 ) -> MlemMeta:
@@ -156,6 +160,7 @@ def load_meta(
     follow_links: bool = True,
     load_value: bool = False,
     fs: Optional[AbstractFileSystem] = None,
+    batch: Optional[int] = None,
     *,
     force_type: Optional[Type[T]] = None,
 ) -> T:
@@ -169,6 +174,7 @@ def load_meta(
     follow_links: bool = True,
     load_value: bool = False,
     fs: Optional[AbstractFileSystem] = None,
+    batch: Optional[int] = None,
     *,
     force_type: Optional[Type[T]] = None,
 ) -> T:
@@ -199,6 +205,9 @@ def load_meta(
         follow_links=follow_links,
     )
     if load_value:
+        if isinstance(meta, DatasetMeta) and batch:
+            meta.load_batch_value(batch)
+            return meta  # type: ignore[return-value]
         meta.load_value()
     if not isinstance(meta, cls):
         raise WrongMetaType(meta, force_type)

--- a/mlem/core/objects.py
+++ b/mlem/core/objects.py
@@ -668,6 +668,9 @@ class DatasetMeta(_WithArtifacts):
     def load_value(self):
         self.dataset = self.reader.read(self.relative_artifacts)
 
+    def load_batch_value(self, batch: int):
+        self.dataset = self.reader.read_batch(self.relative_artifacts, batch)  # type: ignore
+
     def get_value(self):
         return self.data
 

--- a/tests/contrib/test_pandas.py
+++ b/tests/contrib/test_pandas.py
@@ -31,7 +31,6 @@ from mlem.core.metadata import load, save
 from mlem.core.objects import DatasetMeta
 from tests.conftest import (
     dataset_write_read_batch_check,
-    dataset_write_read_batch_unsupported,
     dataset_write_read_check,
     long,
 )
@@ -80,7 +79,12 @@ def pandas_assert(actual: pd.DataFrame, expected: pd.DataFrame):
 
 @pytest.fixture
 def data():
-    return pd.DataFrame([{"a": 1, "b": 3, "c": 5}, {"a": 2, "b": 4, "c": 6}])
+    return pd.DataFrame(
+        [
+            {"a": 1, "b": 3, "c": 5},
+            {"a": 2, "b": 4, "c": 6},
+        ]
+    )
 
 
 @pytest.fixture
@@ -140,20 +144,6 @@ def test_simple_batch_df(data, format):
         format,
         PandasReader,
         pd.DataFrame.equals,
-    )
-
-
-@for_all_formats(
-    exclude=[  # Following file formats support Pandas chunksize parameter
-        "csv",
-        "json",
-        "stata",
-    ]
-)
-def test_unsupported_batch_df(data, format):
-    writer = PandasWriter(format=format)
-    dataset_write_read_batch_unsupported(
-        DatasetType.create(data), 2, writer, PandasReader
     )
 
 

--- a/tests/contrib/test_pandas.py
+++ b/tests/contrib/test_pandas.py
@@ -13,12 +13,12 @@ from sklearn.model_selection import train_test_split
 
 from mlem.api.commands import import_object
 from mlem.contrib.pandas import (
+    PANDAS_FORMATS,
     DataFrameType,
     PandasConfig,
     PandasReader,
     PandasWriter,
     SeriesType,
-    get_pandas_formats,
     pd_type_from_string,
     python_type_from_pd_string_repr,
     python_type_from_pd_type,
@@ -30,6 +30,7 @@ from mlem.core.meta_io import MLEM_EXT
 from mlem.core.metadata import load, save
 from mlem.core.objects import DatasetMeta
 from tests.conftest import (
+    dataset_write_read_batch_check,
     dataset_write_read_batch_unsupported,
     dataset_write_read_check,
     long,
@@ -109,7 +110,7 @@ def series_df_type(series_data):
 
 def for_all_formats(exclude: Union[List[str], Callable] = None):
     ex = exclude if isinstance(exclude, list) else []
-    formats = [name for name in get_pandas_formats() if name not in ex]
+    formats = [name for name in PANDAS_FORMATS if name not in ex]
     mark = pytest.mark.parametrize("format", formats)
     if isinstance(exclude, list):
         return mark
@@ -134,25 +135,11 @@ def test_simple_df(data, format):
     ]
 )
 def test_simple_batch_df(data, format):
-    writer = PandasWriter(format=format)
-    # Batch-reading JSON files require line-delimited data
-    writer_args = None
-    if format == "json":
-        writer_args = {
-            "write_args": {
-                "date_format": "iso",
-                "date_unit": "ns",
-                "orient": "records",
-                "lines": True,
-            }
-        }
-    dataset_write_read_check(
+    dataset_write_read_batch_check(
         DatasetType.create(data),
-        writer,
+        format,
         PandasReader,
         pd.DataFrame.equals,
-        batch=2,
-        writer_args=writer_args,
     )
 
 

--- a/tests/contrib/test_pandas.py
+++ b/tests/contrib/test_pandas.py
@@ -125,13 +125,12 @@ def test_simple_df(data, format):
 
 
 @for_all_formats(
-    exclude=[  # Following file formats do not support chunksize parameter
+    exclude=[  # Following file formats do not support Pandas chunksize parameter
         "html",
         "excel",
         "parquet",
         "feather",
         "pickle",
-        "stata",  # TODO: Add support for stata
     ]
 )
 def test_simple_batch_df(data, format):
@@ -158,10 +157,10 @@ def test_simple_batch_df(data, format):
 
 
 @for_all_formats(
-    exclude=[  # Following file formats do not support chunksize parameter
+    exclude=[  # Following file formats support Pandas chunksize parameter
         "csv",
         "json",
-        "stata",  # TODO: Add support for stata
+        "stata",
     ]
 )
 def test_unsupported_batch_df(data, format):

--- a/tests/core/test_dataset_io.py
+++ b/tests/core/test_dataset_io.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 
 from mlem.contrib.numpy import NumpyArrayReader, NumpyArrayWriter
-from mlem.contrib.pandas import PandasReader, PandasWriter, get_pandas_formats
+from mlem.contrib.pandas import PANDAS_FORMATS, PandasReader, PandasWriter
 from mlem.core.artifacts import FSSpecStorage
 from mlem.core.dataset_type import DatasetType
 
@@ -27,7 +27,7 @@ def test_numpy_read_write():
     assert np.array_equal(dataset2.data, data)
 
 
-@pytest.mark.parametrize("format", list(get_pandas_formats().keys()))
+@pytest.mark.parametrize("format", list(PANDAS_FORMATS.keys()))
 def test_pandas_read_write(format):
     data = pd.DataFrame([{"a": 1, "b": 2}])
     dataset = DatasetType.create(data)

--- a/tests/core/test_dataset_io.py
+++ b/tests/core/test_dataset_io.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 
 from mlem.contrib.numpy import NumpyArrayReader, NumpyArrayWriter
-from mlem.contrib.pandas import PANDAS_FORMATS, PandasReader, PandasWriter
+from mlem.contrib.pandas import PandasReader, PandasWriter, get_pandas_formats
 from mlem.core.artifacts import FSSpecStorage
 from mlem.core.dataset_type import DatasetType
 
@@ -27,7 +27,7 @@ def test_numpy_read_write():
     assert np.array_equal(dataset2.data, data)
 
 
-@pytest.mark.parametrize("format", list(PANDAS_FORMATS.keys()))
+@pytest.mark.parametrize("format", list(get_pandas_formats().keys()))
 def test_pandas_read_write(format):
     data = pd.DataFrame([{"a": 1, "b": 2}])
     dataset = DatasetType.create(data)


### PR DESCRIPTION
### Context
Some datasets are large and rather than dealing them with one big block, we could split the data into chunks. This PR adds batch-reading support for data formats which provides the `chunksize` parameter using the Pandas API.

Supported formats:

- [x] CSV
- [x] JSON
- [x] Stata

### Modifications
- `mlem/cli/apply.py` - Added `batch` parameter when calling apply method - supports both importing data on/off-the-fly workflows
- `mlem/api/utils.py` - Added batch reading support when getting Dataset value
- `mlem/core/errors.py` - Added new errors `UnsupportedDatasetBatchLoadingType` and `DatasetBatchLoadingJSONError` for batch-reading workflows
- `mlem/contrib/pandas.py` - Added batch-reading support for CSV, JSON data formats
- `tests/contrib/test_pandas.py` - Added tests for supported batch-reading data formats, exception tests for unsupported batch-reading data formats 

**Which issue(s) this PR fixes:**
Fixes https://github.com/iterative/mlem/issues/23