### PR TITLE
Support batch-reading for data-types with chunksize parameter

### DIFF
--- a/mlem/api/commands.py
+++ b/mlem/api/commands.py
@@ -90,13 +90,9 @@ def apply(
         res: Any = []
         for part in data:
             batch_dataset = get_dataset_value(part, batch)
-            while True:
-                try:
-                    chunk = next(batch_dataset)
-                    preds = w.call_method(resolved_method, chunk.data)
-                    res = [*res, *preds]
-                except StopIteration:
-                    break
+            for chunk in batch_dataset:
+                preds = w.call_method(resolved_method, chunk.data)
+                res += [*preds]
         res = [np.array(res)]
     else:
         res = [

--- a/mlem/api/utils.py
+++ b/mlem/api/utils.py
@@ -7,14 +7,17 @@ from mlem.core.metadata import load, load_meta
 from mlem.core.objects import DatasetMeta, MlemMeta, ModelMeta
 
 
-def get_dataset_value(dataset: Any) -> Any:
+def get_dataset_value(dataset: Any, batch: Optional[int] = None) -> Any:
     if isinstance(dataset, str):
         return load(dataset)
     if isinstance(dataset, DatasetMeta):
         # TODO: https://github.com/iterative/mlem/issues/29
         #  fix discrepancies between model and data meta objects
         if not hasattr(dataset.dataset, "data"):
-            dataset.load_value()
+            if batch:
+                return dataset.read_batch(batch)
+            else:
+                dataset.load_value()
         return dataset.data
 
     # TODO: https://github.com/iterative/mlem/issues/29

--- a/mlem/cli/apply.py
+++ b/mlem/cli/apply.py
@@ -18,6 +18,7 @@ from mlem.cli.main import (
     option_rev,
 )
 from mlem.core.dataset_type import DatasetAnalyzer
+from mlem.core.errors import UnsupportedDatasetBatchLoading
 from mlem.core.import_objects import ImportHook
 from mlem.core.metadata import load_meta
 from mlem.core.objects import DatasetMeta, ModelMeta
@@ -60,6 +61,9 @@ def apply(
         # TODO: change ImportHook to MlemObject to support ext machinery
         help=f"Specify how to read data file for import. Available types: {list_implementations(ImportHook)}",
     ),
+    batch: Optional[int] = Option(
+        None, "-b", "--batch", help="Batch size for reading data in batches."
+    ),
     link: bool = option_link,
     external: bool = option_external,
     json: bool = option_json,
@@ -82,6 +86,10 @@ def apply(
 
     with set_echo(None if json else ...):
         if import_:
+            if batch:
+                raise UnsupportedDatasetBatchLoading(
+                    "Batch data loading is currently not supported for loading data on-the-fly"
+                )
             dataset = import_object(
                 data, repo=data_repo, rev=data_rev, type_=import_type
             )
@@ -90,7 +98,7 @@ def apply(
                 data,
                 data_repo,
                 data_rev,
-                load_value=True,
+                load_value=batch is None,
                 force_type=DatasetMeta,
             )
         meta = load_meta(model, repo, rev, force_type=ModelMeta)
@@ -102,6 +110,7 @@ def apply(
             output=output,
             link=link,
             external=external,
+            batch=batch,
         )
     if output is None and json:
         print(

--- a/mlem/contrib/numpy.py
+++ b/mlem/contrib/numpy.py
@@ -1,5 +1,5 @@
 from types import ModuleType
-from typing import Any, ClassVar, List, Optional, Tuple, Type, Union
+from typing import Any, ClassVar, Iterator, List, Optional, Tuple, Type, Union
 
 import numpy as np
 from pydantic import BaseModel, conlist, create_model
@@ -192,3 +192,8 @@ class NumpyArrayReader(DatasetReader):
         with artifacts[DatasetWriter.art_name].open() as f:
             data = np.load(f)[DATA_KEY]
         return self.dataset_type.copy().bind(data)
+
+    def read_batch(
+        self, artifacts: Artifacts, batch: int
+    ) -> Iterator[DatasetType]:
+        raise NotImplementedError

--- a/mlem/contrib/pandas.py
+++ b/mlem/contrib/pandas.py
@@ -9,6 +9,7 @@ from typing import (
     Callable,
     ClassVar,
     Dict,
+    Iterator,
     List,
     Optional,
     Tuple,
@@ -44,7 +45,11 @@ from mlem.core.dataset_type import (
     DatasetType,
     DatasetWriter,
 )
-from mlem.core.errors import DeserializationError, SerializationError
+from mlem.core.errors import (
+    DeserializationError,
+    SerializationError,
+    UnsupportedDatasetBatchLoadingType,
+)
 from mlem.core.import_objects import ExtImportHook
 from mlem.core.meta_io import Location
 from mlem.core.metadata import get_object_metadata
@@ -472,10 +477,45 @@ PANDAS_FORMATS = {
     "pickle": PandasFormat(  # TODO buffer closed error for some reason
         pd.read_pickle, pd.DataFrame.to_pickle, file_name="data.pkl"
     ),
-    "strata": PandasFormat(  # TODO int32 converts to int64 for some reason
+    "stata": PandasFormat(  # TODO int32 converts to int64 for some reason
         pd.read_stata, pd.DataFrame.to_stata, write_args={"write_index": False}
     ),
 }
+
+
+def get_pandas_batch_formats(batch: int):
+    PANDAS_FORMATS = {
+        "csv": PandasFormat(
+            pd.read_csv,
+            pd.DataFrame.to_csv,
+            file_name="data.csv",
+            write_args={"index": False},
+            read_args={"chunksize": batch},
+        ),
+        "json": PandasFormat(
+            pd.read_json,
+            pd.DataFrame.to_json,
+            file_name="data.json",
+            write_args={
+                "date_format": "iso",
+                "date_unit": "ns",
+                "orient": "records",
+                "lines": True,
+            },
+            # Pandas supports batch-reading for JSON only if the JSON file is line-delimited
+            # and orient to be records
+            # https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html#line-delimited-json
+            read_args={"chunksize": batch, "orient": "records", "lines": True},
+        ),
+        "stata": PandasFormat(  # TODO int32 converts to int64 for some reason
+            pd.read_stata,
+            pd.DataFrame.to_stata,
+            write_args={"write_index": False},
+            read_args={"chunksize": batch},
+        ),
+    }
+
+    return PANDAS_FORMATS
 
 
 class _PandasIO(BaseModel):
@@ -504,6 +544,34 @@ class PandasReader(_PandasIO, DatasetReader):
         return self.dataset_type.copy().bind(
             self.dataset_type.align(self.fmt.read(artifacts))
         )
+
+    def read_batch(
+        self, artifacts: Artifacts, batch: int
+    ) -> Iterator[DatasetType]:
+        batch_formats = get_pandas_batch_formats(batch)
+        if self.format not in batch_formats:
+            raise UnsupportedDatasetBatchLoadingType(self.format)
+        fmt = batch_formats[self.format]
+
+        read_kwargs = {}
+        if fmt.read_args:
+            read_kwargs.update(fmt.read_args)
+        with artifacts[DatasetWriter.art_name].open() as f:
+            iter_df = fmt.read_func(f, **read_kwargs)
+            for df in iter_df:
+                if self.format == "csv":
+                    unnamed = {}
+                    for col in df.columns:
+                        if col.startswith("Unnamed: "):
+                            unnamed[col] = ""
+                    if unnamed:
+                        df = df.rename(unnamed, axis=1)
+                else:
+                    df = df.reset_index(drop=True)
+
+                yield self.dataset_type.copy().bind(
+                    self.dataset_type.align(df)
+                )
 
 
 class PandasWriter(DatasetWriter, _PandasIO):

--- a/mlem/core/dataset_type.py
+++ b/mlem/core/dataset_type.py
@@ -3,7 +3,17 @@ Base classes for working with datasets in MLEM
 """
 import builtins
 from abc import ABC, abstractmethod
-from typing import Any, ClassVar, Dict, List, Optional, Sized, Tuple, Type
+from typing import (
+    Any,
+    ClassVar,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Sized,
+    Tuple,
+    Type,
+)
 
 from pydantic import BaseModel
 from pydantic.main import create_model
@@ -402,6 +412,12 @@ class DatasetReader(MlemABC, ABC):
 
     @abstractmethod
     def read(self, artifacts: Artifacts) -> DatasetType:
+        raise NotImplementedError
+
+    @abstractmethod
+    def read_batch(
+        self, artifacts: Artifacts, batch: int
+    ) -> Iterator[DatasetType]:
         raise NotImplementedError
 
 

--- a/mlem/core/errors.py
+++ b/mlem/core/errors.py
@@ -70,6 +70,25 @@ class MlemObjectNotLoadedError(ValueError, MlemError):
     """Thrown if model or dataset value is not loaded"""
 
 
+class UnsupportedDatasetBatchLoadingType(ValueError, MlemError):
+    """Thrown if batch loading of dataset with unsupported file type is called"""
+
+    _message = "Batch-loading Dataset of type '{dataset_type}' is currently not supported. Please remove batch parameter."
+
+    def __init__(
+        self,
+        dataset_type,
+    ) -> None:
+
+        self.dataset_type = dataset_type
+        self.message = self._message.format(dataset_type=dataset_type)
+        super().__init__(self.message)
+
+
+class UnsupportedDatasetBatchLoading(MlemError):
+    """Thrown if batch loading of dataset is called for import workflow"""
+
+
 class WrongMethodError(ValueError, MlemError):
     """Thrown if wrong method name for model is provided"""
 

--- a/mlem/core/metadata.py
+++ b/mlem/core/metadata.py
@@ -107,6 +107,7 @@ def load(
     path: str,
     repo: Optional[str] = None,
     rev: Optional[str] = None,
+    batch: Optional[int] = None,
     follow_links: bool = True,
 ) -> Any:
     """Load python object saved by MLEM
@@ -126,8 +127,10 @@ def load(
         repo=repo,
         rev=rev,
         follow_links=follow_links,
-        load_value=True,
+        load_value=batch is None,
     )
+    if isinstance(meta, DatasetMeta) and batch:
+        return meta.read_batch(batch)
     return meta.get_value()
 
 

--- a/mlem/core/objects.py
+++ b/mlem/core/objects.py
@@ -14,6 +14,7 @@ from typing import (
     Dict,
     Generic,
     Iterable,
+    Iterator,
     List,
     Optional,
     Tuple,
@@ -672,6 +673,9 @@ class DatasetMeta(_WithArtifacts):
 
     def load_value(self):
         self.dataset = self.reader.read(self.relative_artifacts)
+
+    def read_batch(self, batch: int) -> Iterator[DatasetType]:
+        return self.reader.read_batch(self.relative_artifacts, batch)  # type: ignore
 
     def get_value(self):
         return self.data

--- a/mlem/core/objects.py
+++ b/mlem/core/objects.py
@@ -675,7 +675,8 @@ class DatasetMeta(_WithArtifacts):
         self.dataset = self.reader.read(self.relative_artifacts)
 
     def read_batch(self, batch: int) -> Iterator[DatasetType]:
-        return self.reader.read_batch(self.relative_artifacts, batch)  # type: ignore
+        assert isinstance(self.reader, DatasetReader)
+        return self.reader.read_batch(self.relative_artifacts, batch)
 
     def get_value(self):
         return self.data

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import os
 import posixpath
 import tempfile
 from pathlib import Path
-from typing import Any, Callable, Type
+from typing import Any, Callable, Iterator, Type
 
 import git
 import pandas as pd
@@ -18,6 +18,7 @@ from mlem import CONFIG
 from mlem.api import init, save
 from mlem.constants import PREDICT_ARG_NAME, PREDICT_METHOD_NAME
 from mlem.contrib.fastapi import FastAPIServer
+from mlem.contrib.pandas import PandasReader, get_pandas_batch_formats
 from mlem.contrib.sklearn import SklearnModel
 from mlem.core.artifacts import LOCAL_STORAGE, FSSpecStorage, LocalArtifact
 from mlem.core.dataset_type import DatasetReader, DatasetType, DatasetWriter
@@ -326,6 +327,40 @@ def dataset_write_read_check(
                 assert custom_eq(new.data, dataset.data)
             else:
                 assert new.data == dataset.data
+
+
+def dataset_write_read_batch_check(
+    dataset: DatasetType,
+    format: str,
+    reader_type: Type[DatasetReader] = None,
+    custom_eq: Callable[[Any, Any], bool] = None,
+):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        BATCH_SIZE = 2
+        storage = LOCAL_STORAGE
+
+        fmt = get_pandas_batch_formats(BATCH_SIZE)[format]
+        art = fmt.write(dataset.data, storage, posixpath.join(tmpdir, "data"))
+        reader = PandasReader(dataset_type=dataset, format=format)
+        artifacts = {"data": art}
+        if reader_type is not None:
+            assert isinstance(reader, reader_type)
+
+        df_iterable: Iterator = reader.read_batch(artifacts, BATCH_SIZE)
+        df = None
+        col_types = None
+        while True:
+            try:
+                chunk = next(df_iterable)
+                if df is None:
+                    df = pd.DataFrame(columns=chunk.columns, dtype=col_types)
+                    col_types = dict(zip(chunk.columns, chunk.dtypes))
+                    df = df.astype(dtype=col_types)
+                df = pd.concat([df, chunk.data], ignore_index=True)
+            except StopIteration:
+                break
+
+        assert custom_eq(df, dataset.data)
 
 
 def check_model_type_common_interface(

--- a/tests/contrib/test_pandas.py
+++ b/tests/contrib/test_pandas.py
@@ -29,7 +29,11 @@ from mlem.core.errors import DeserializationError, SerializationError
 from mlem.core.meta_io import MLEM_EXT
 from mlem.core.metadata import load, save
 from mlem.core.objects import DatasetMeta
-from tests.conftest import dataset_write_read_check, long
+from tests.conftest import (
+    dataset_write_read_batch_check,
+    dataset_write_read_check,
+    long,
+)
 
 PD_DATA_FRAME = pd.DataFrame(
     [
@@ -120,6 +124,24 @@ def test_simple_df(data, format):
     )
 
 
+@for_all_formats(
+    exclude=[  # Following file formats do not support Pandas chunksize parameter
+        "html",
+        "excel",
+        "parquet",
+        "feather",
+        "pickle",
+    ]
+)
+def test_simple_batch_df(data, format):
+    dataset_write_read_batch_check(
+        DatasetType.create(data),
+        format,
+        PandasReader,
+        pd.DataFrame.equals,
+    )
+
+
 @for_all_formats
 def test_with_index(data, format):
     writer = PandasWriter(format=format)
@@ -146,7 +168,7 @@ def test_with_multiindex(data, format):
     exclude=[
         "excel",  # Excel does not support datetimes with timezones
         "parquet",  # Casting from timestamp[ns] to timestamp[ms] would lose data
-        "strata",  # Data type datetime64[ns, UTC] not supported.
+        "stata",  # Data type datetime64[ns, UTC] not supported.
     ]
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Context
Some datasets are large and rather than dealing them with one big block, we could split the data into chunks. This PR adds batch-reading support for data formats which provides the `chunksize` parameter using the Pandas API.

Related PR: https://github.com/iterative/mlem/pull/206

Supported formats:

- [x] CSV
- [x] JSON
- [x] Stata

### Modifications
- `mlem/cli/apply.py` - Added `batch` parameter when calling apply method - supports both importing data on/off-the-fly workflows
- `mlem/api/utils.py` - Added batch reading support when getting Dataset value
- `mlem/core/errors.py` - Added new errors `UnsupportedDatasetBatchLoadingType` and `UnsupportedDatasetBatchLoading` for batch-reading workflows
- `mlem/contrib/pandas.py` - Added batch-reading support for CSV, JSON, Stata data formats
- `tests/contrib/test_pandas.py` - Added tests for supported batch-reading data formats

**Which issue(s) this PR fixes:**
Fixes https://github.com/iterative/mlem/issues/23