### PR TITLE
Support batch-reading for data-types with chunksize parameter

### DIFF
--- a/mlem/api/commands.py
+++ b/mlem/api/commands.py
@@ -5,6 +5,7 @@ import posixpath
 from collections import defaultdict
 from typing import Any, Dict, Iterable, List, Optional, Type, Union
 
+import numpy as np
 from fsspec import AbstractFileSystem
 from fsspec.implementations.local import LocalFileSystem
 
@@ -59,6 +60,7 @@ def apply(
     target_repo: str = None,
     link: bool = None,
     external: bool = None,
+    batch: Optional[int] = None,
 ) -> Optional[Any]:
     """Apply provided model against provided data
 
@@ -85,10 +87,19 @@ def apply(
     except WrongMethodError:
         resolved_method = PREDICT_METHOD_NAME
     echo(EMOJI_APPLY + f"Applying `{resolved_method}` method...")
-    res = [
-        w.call_method(resolved_method, get_dataset_value(part))
-        for part in data
-    ]
+    if batch:
+        res: Any = []
+        for part in data:
+            batch_dataset = get_dataset_value(part, batch)
+            for chunk in batch_dataset:
+                preds = w.call_method(resolved_method, chunk.data)
+                res += [*preds]
+        res = [np.array(res)]
+    else:
+        res = [
+            w.call_method(resolved_method, get_dataset_value(part))
+            for part in data
+        ]
     if output is None:
         if len(res) == 1:
             return res[0]

--- a/mlem/api/commands.py
+++ b/mlem/api/commands.py
@@ -60,7 +60,7 @@ def apply(
     target_repo: str = None,
     link: bool = None,
     external: bool = None,
-    batch: Optional[int] = None,
+    batch_size: Optional[int] = None,
 ) -> Optional[Any]:
     """Apply provided model against provided data
 
@@ -87,10 +87,10 @@ def apply(
     except WrongMethodError:
         resolved_method = PREDICT_METHOD_NAME
     echo(EMOJI_APPLY + f"Applying `{resolved_method}` method...")
-    if batch:
+    if batch_size:
         res: Any = []
         for part in data:
-            batch_dataset = get_dataset_value(part, batch)
+            batch_dataset = get_dataset_value(part, batch_size)
             for chunk in batch_dataset:
                 preds = w.call_method(resolved_method, chunk.data)
                 res += [*preds]

--- a/mlem/api/utils.py
+++ b/mlem/api/utils.py
@@ -7,17 +7,16 @@ from mlem.core.metadata import load, load_meta
 from mlem.core.objects import DatasetMeta, MlemMeta, ModelMeta
 
 
-def get_dataset_value(dataset: Any, batch: Optional[int] = None) -> Any:
+def get_dataset_value(dataset: Any, batch_size: Optional[int] = None) -> Any:
     if isinstance(dataset, str):
         return load(dataset)
     if isinstance(dataset, DatasetMeta):
         # TODO: https://github.com/iterative/mlem/issues/29
         #  fix discrepancies between model and data meta objects
         if not hasattr(dataset.dataset, "data"):
-            if batch:
-                return dataset.read_batch(batch)
-            else:
-                dataset.load_value()
+            if batch_size:
+                return dataset.read_batch(batch_size)
+            dataset.load_value()
         return dataset.data
 
     # TODO: https://github.com/iterative/mlem/issues/29

--- a/mlem/api/utils.py
+++ b/mlem/api/utils.py
@@ -7,14 +7,17 @@ from mlem.core.metadata import load, load_meta
 from mlem.core.objects import DatasetMeta, MlemMeta, ModelMeta
 
 
-def get_dataset_value(dataset: Any) -> Any:
+def get_dataset_value(dataset: Any, batch: Optional[int] = None) -> Any:
     if isinstance(dataset, str):
         return load(dataset)
     if isinstance(dataset, DatasetMeta):
         # TODO: https://github.com/iterative/mlem/issues/29
         #  fix discrepancies between model and data meta objects
         if not hasattr(dataset.dataset, "data"):
-            dataset.load_value()
+            if batch:
+                return dataset.read_batch(batch)
+            else:
+                dataset.load_value()
         return dataset.data
 
     # TODO: https://github.com/iterative/mlem/issues/29

--- a/mlem/cli/apply.py
+++ b/mlem/cli/apply.py
@@ -55,8 +55,11 @@ def apply(
         # TODO: change ImportHook to MlemObject to support ext machinery
         help=f"Specify how to read data file for import. Available types: {list_implementations(ImportHook)}",
     ),
-    batch: Optional[int] = Option(
-        None, "-b", "--batch", help="Batch size for reading data in batches."
+    batch_size: Optional[int] = Option(
+        None,
+        "-b",
+        "--batch_size",
+        help="Batch size for reading data in batches.",
     ),
     link: bool = option_link,
     external: bool = option_external,
@@ -80,7 +83,7 @@ def apply(
 
     with set_echo(None if json else ...):
         if import_:
-            if batch:
+            if batch_size:
                 raise UnsupportedDatasetBatchLoading(
                     "Batch data loading is currently not supported for loading data on-the-fly"
                 )
@@ -92,7 +95,7 @@ def apply(
                 data,
                 data_repo,
                 data_rev,
-                load_value=batch is None,
+                load_value=batch_size is None,
                 force_type=DatasetMeta,
             )
         meta = load_meta(model, repo, rev, force_type=ModelMeta)
@@ -104,7 +107,7 @@ def apply(
             output=output,
             link=link,
             external=external,
-            batch=batch,
+            batch_size=batch_size,
         )
     if output is None and json:
         print(

--- a/mlem/contrib/lightgbm.py
+++ b/mlem/contrib/lightgbm.py
@@ -1,7 +1,7 @@
 import os
 import posixpath
 import tempfile
-from typing import Any, ClassVar, List, Optional, Tuple, Type
+from typing import Any, ClassVar, Iterator, List, Optional, Tuple, Type
 
 import lightgbm as lgb
 from pydantic import BaseModel
@@ -113,6 +113,11 @@ class LightGBMDatasetReader(DatasetReader):
                 inner_dataset_type.data, label=self.label, free_raw_data=False
             )
         )
+
+    def read_batch(
+        self, artifacts: Artifacts, batch: int
+    ) -> Iterator[DatasetType]:
+        raise NotImplementedError
 
 
 class LightGBMModelIO(ModelIO):

--- a/mlem/contrib/lightgbm.py
+++ b/mlem/contrib/lightgbm.py
@@ -115,7 +115,7 @@ class LightGBMDatasetReader(DatasetReader):
         )
 
     def read_batch(
-        self, artifacts: Artifacts, batch: int
+        self, artifacts: Artifacts, batch_size: int
     ) -> Iterator[DatasetType]:
         raise NotImplementedError
 

--- a/mlem/contrib/numpy.py
+++ b/mlem/contrib/numpy.py
@@ -1,5 +1,5 @@
 from types import ModuleType
-from typing import Any, ClassVar, List, Optional, Tuple, Type, Union
+from typing import Any, ClassVar, Iterator, List, Optional, Tuple, Type, Union
 
 import numpy as np
 from pydantic import BaseModel, conlist, create_model
@@ -215,3 +215,8 @@ class NumpyArrayReader(DatasetReader):
         with artifacts[DatasetWriter.art_name].open() as f:
             data = np.load(f)[DATA_KEY]
         return self.dataset_type.copy().bind(data)
+
+    def read_batch(
+        self, artifacts: Artifacts, batch: int
+    ) -> Iterator[DatasetType]:
+        raise NotImplementedError

--- a/mlem/contrib/numpy.py
+++ b/mlem/contrib/numpy.py
@@ -188,6 +188,11 @@ class NumpyNumberReader(DatasetReader):
             data = self.dataset_type.actual_type(res)
             return self.dataset_type.copy().bind(data)
 
+    def read_batch(
+        self, artifacts: Artifacts, batch: int
+    ) -> Iterator[DatasetType]:
+        raise NotImplementedError
+
 
 class NumpyArrayWriter(DatasetWriter):
     """DatasetWriter implementation for numpy ndarray"""

--- a/mlem/contrib/numpy.py
+++ b/mlem/contrib/numpy.py
@@ -189,7 +189,7 @@ class NumpyNumberReader(DatasetReader):
             return self.dataset_type.copy().bind(data)
 
     def read_batch(
-        self, artifacts: Artifacts, batch: int
+        self, artifacts: Artifacts, batch_size: int
     ) -> Iterator[DatasetType]:
         raise NotImplementedError
 
@@ -222,6 +222,6 @@ class NumpyArrayReader(DatasetReader):
         return self.dataset_type.copy().bind(data)
 
     def read_batch(
-        self, artifacts: Artifacts, batch: int
+        self, artifacts: Artifacts, batch_size: int
     ) -> Iterator[DatasetType]:
         raise NotImplementedError

--- a/mlem/contrib/pandas.py
+++ b/mlem/contrib/pandas.py
@@ -598,6 +598,11 @@ class PandasSeriesReader(_PandasIO, DatasetReader):
             data.index.name = None
         return self.dataset_type.copy().bind(data)
 
+    def read_batch(
+        self, artifacts: Artifacts, batch: int
+    ) -> Iterator[DatasetType]:
+        raise NotImplementedError
+
 
 class PandasSeriesWriter(DatasetWriter, _PandasIO):
     """DatasetWriter for pandas series"""

--- a/mlem/contrib/pandas.py
+++ b/mlem/contrib/pandas.py
@@ -9,6 +9,7 @@ from typing import (
     Callable,
     ClassVar,
     Dict,
+    Iterator,
     List,
     Optional,
     Tuple,
@@ -44,7 +45,11 @@ from mlem.core.dataset_type import (
     DatasetType,
     DatasetWriter,
 )
-from mlem.core.errors import DeserializationError, SerializationError
+from mlem.core.errors import (
+    DeserializationError,
+    SerializationError,
+    UnsupportedDatasetBatchLoadingType,
+)
 from mlem.core.import_objects import ExtImportHook
 from mlem.core.meta_io import Location
 from mlem.core.metadata import get_object_metadata
@@ -524,6 +529,41 @@ PANDAS_SERIES_FORMATS = {
 }
 
 
+def get_pandas_batch_formats(batch: int):
+    PANDAS_FORMATS = {
+        "csv": PandasFormat(
+            pd.read_csv,
+            pd.DataFrame.to_csv,
+            file_name="data.csv",
+            write_args={"index": False},
+            read_args={"chunksize": batch},
+        ),
+        "json": PandasFormat(
+            pd.read_json,
+            pd.DataFrame.to_json,
+            file_name="data.json",
+            write_args={
+                "date_format": "iso",
+                "date_unit": "ns",
+                "orient": "records",
+                "lines": True,
+            },
+            # Pandas supports batch-reading for JSON only if the JSON file is line-delimited
+            # and orient to be records
+            # https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html#line-delimited-json
+            read_args={"chunksize": batch, "orient": "records", "lines": True},
+        ),
+        "stata": PandasFormat(  # TODO int32 converts to int64 for some reason
+            pd.read_stata,
+            pd.DataFrame.to_stata,
+            write_args={"write_index": False},
+            read_args={"chunksize": batch},
+        ),
+    }
+
+    return PANDAS_FORMATS
+
+
 class _PandasIO(BaseModel):
     format: str
 
@@ -586,6 +626,34 @@ class PandasReader(_PandasIO, DatasetReader):
         return self.dataset_type.copy().bind(
             self.dataset_type.align(self.fmt.read(artifacts))
         )
+
+    def read_batch(
+        self, artifacts: Artifacts, batch: int
+    ) -> Iterator[DatasetType]:
+        batch_formats = get_pandas_batch_formats(batch)
+        if self.format not in batch_formats:
+            raise UnsupportedDatasetBatchLoadingType(self.format)
+        fmt = batch_formats[self.format]
+
+        read_kwargs = {}
+        if fmt.read_args:
+            read_kwargs.update(fmt.read_args)
+        with artifacts[DatasetWriter.art_name].open() as f:
+            iter_df = fmt.read_func(f, **read_kwargs)
+            for df in iter_df:
+                if self.format == "csv":
+                    unnamed = {}
+                    for col in df.columns:
+                        if col.startswith("Unnamed: "):
+                            unnamed[col] = ""
+                    if unnamed:
+                        df = df.rename(unnamed, axis=1)
+                else:
+                    df = df.reset_index(drop=True)
+
+                yield self.dataset_type.copy().bind(
+                    self.dataset_type.align(df)
+                )
 
 
 class PandasWriter(DatasetWriter, _PandasIO):

--- a/mlem/contrib/torch.py
+++ b/mlem/contrib/torch.py
@@ -101,7 +101,7 @@ class TorchTensorReader(DatasetReader):
             return self.dataset_type.copy().bind(data)
 
     def read_batch(
-        self, artifacts: Artifacts, batch: int
+        self, artifacts: Artifacts, batch_size: int
     ) -> Iterator[DatasetType]:
         raise NotImplementedError
 

--- a/mlem/contrib/torch.py
+++ b/mlem/contrib/torch.py
@@ -1,4 +1,4 @@
-from typing import Any, ClassVar, Optional, Tuple
+from typing import Any, ClassVar, Iterator, Optional, Tuple
 
 import torch
 
@@ -99,6 +99,11 @@ class TorchTensorReader(DatasetReader):
         with artifacts[DatasetWriter.art_name].open() as f:
             data = torch.load(f)
             return self.dataset_type.copy().bind(data)
+
+    def read_batch(
+        self, artifacts: Artifacts, batch: int
+    ) -> Iterator[DatasetType]:
+        raise NotImplementedError
 
 
 class TorchModelIO(ModelIO):

--- a/mlem/core/dataset_type.py
+++ b/mlem/core/dataset_type.py
@@ -218,6 +218,11 @@ class PrimitiveReader(DatasetReader):
                 data = self.dataset_type.to_type(res)
             return self.dataset_type.copy().bind(data)
 
+    def read_batch(
+        self, artifacts: Artifacts, batch: int
+    ) -> Iterator[DatasetType]:
+        raise NotImplementedError
+
 
 class ListDatasetType(DatasetType, DatasetSerializer):
     """
@@ -294,6 +299,11 @@ class ListReader(DatasetReader):
             elem_dtype = reader.read(artifacts[str(i)])  # type: ignore
             data_list.append(elem_dtype.data)
         return self.dataset_type.copy().bind(data_list)
+
+    def read_batch(
+        self, artifacts: Artifacts, batch: int
+    ) -> Iterator[DatasetType]:
+        raise NotImplementedError
 
 
 class _TupleLikeDatasetType(DatasetType, DatasetSerializer):
@@ -392,6 +402,11 @@ class _TupleLikeDatasetReader(DatasetReader):
             data_list.append(elem_dtype.data)
         data_list = self.dataset_type.actual_type(data_list)
         return self.dataset_type.copy().bind(data_list)
+
+    def read_batch(
+        self, artifacts: Artifacts, batch: int
+    ) -> Iterator[DatasetType]:
+        raise NotImplementedError
 
 
 class TupleLikeListDatasetType(_TupleLikeDatasetType):
@@ -547,6 +562,11 @@ class DictReader(DatasetReader):
             v_dataset_type = dtype_reader.read(artifacts[key])  # type: ignore
             data_dict[key] = v_dataset_type.data
         return self.dataset_type.copy().bind(data_dict)
+
+    def read_batch(
+        self, artifacts: Artifacts, batch: int
+    ) -> Iterator[DatasetType]:
+        raise NotImplementedError
 
 
 #

--- a/mlem/core/dataset_type.py
+++ b/mlem/core/dataset_type.py
@@ -4,7 +4,17 @@ Base classes for working with datasets in MLEM
 import builtins
 import posixpath
 from abc import ABC, abstractmethod
-from typing import Any, ClassVar, Dict, List, Optional, Sized, Tuple, Type
+from typing import (
+    Any,
+    ClassVar,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Sized,
+    Tuple,
+    Type,
+)
 
 import flatdict
 from pydantic import BaseModel
@@ -112,6 +122,12 @@ class DatasetReader(MlemABC, ABC):
 
     @abstractmethod
     def read(self, artifacts: Artifacts) -> DatasetType:
+        raise NotImplementedError
+
+    @abstractmethod
+    def read_batch(
+        self, artifacts: Artifacts, batch: int
+    ) -> Iterator[DatasetType]:
         raise NotImplementedError
 
 

--- a/mlem/core/dataset_type.py
+++ b/mlem/core/dataset_type.py
@@ -126,7 +126,7 @@ class DatasetReader(MlemABC, ABC):
 
     @abstractmethod
     def read_batch(
-        self, artifacts: Artifacts, batch: int
+        self, artifacts: Artifacts, batch_size: int
     ) -> Iterator[DatasetType]:
         raise NotImplementedError
 
@@ -219,7 +219,7 @@ class PrimitiveReader(DatasetReader):
             return self.dataset_type.copy().bind(data)
 
     def read_batch(
-        self, artifacts: Artifacts, batch: int
+        self, artifacts: Artifacts, batch_size: int
     ) -> Iterator[DatasetType]:
         raise NotImplementedError
 
@@ -301,7 +301,7 @@ class ListReader(DatasetReader):
         return self.dataset_type.copy().bind(data_list)
 
     def read_batch(
-        self, artifacts: Artifacts, batch: int
+        self, artifacts: Artifacts, batch_size: int
     ) -> Iterator[DatasetType]:
         raise NotImplementedError
 
@@ -404,7 +404,7 @@ class _TupleLikeDatasetReader(DatasetReader):
         return self.dataset_type.copy().bind(data_list)
 
     def read_batch(
-        self, artifacts: Artifacts, batch: int
+        self, artifacts: Artifacts, batch_size: int
     ) -> Iterator[DatasetType]:
         raise NotImplementedError
 
@@ -564,7 +564,7 @@ class DictReader(DatasetReader):
         return self.dataset_type.copy().bind(data_dict)
 
     def read_batch(
-        self, artifacts: Artifacts, batch: int
+        self, artifacts: Artifacts, batch_size: int
     ) -> Iterator[DatasetType]:
         raise NotImplementedError
 

--- a/mlem/core/errors.py
+++ b/mlem/core/errors.py
@@ -70,6 +70,25 @@ class MlemObjectNotLoadedError(ValueError, MlemError):
     """Thrown if model or dataset value is not loaded"""
 
 
+class UnsupportedDatasetBatchLoadingType(ValueError, MlemError):
+    """Thrown if batch loading of dataset with unsupported file type is called"""
+
+    _message = "Batch-loading Dataset of type '{dataset_type}' is currently not supported. Please remove batch parameter."
+
+    def __init__(
+        self,
+        dataset_type,
+    ) -> None:
+
+        self.dataset_type = dataset_type
+        self.message = self._message.format(dataset_type=dataset_type)
+        super().__init__(self.message)
+
+
+class UnsupportedDatasetBatchLoading(MlemError):
+    """Thrown if batch loading of dataset is called for import workflow"""
+
+
 class WrongMethodError(ValueError, MlemError):
     """Thrown if wrong method name for model is provided"""
 

--- a/mlem/core/metadata.py
+++ b/mlem/core/metadata.py
@@ -107,6 +107,7 @@ def load(
     path: str,
     repo: Optional[str] = None,
     rev: Optional[str] = None,
+    batch: Optional[int] = None,
     follow_links: bool = True,
 ) -> Any:
     """Load python object saved by MLEM
@@ -126,8 +127,10 @@ def load(
         repo=repo,
         rev=rev,
         follow_links=follow_links,
-        load_value=True,
+        load_value=batch is None,
     )
+    if isinstance(meta, DatasetMeta) and batch:
+        return meta.read_batch(batch)
     return meta.get_value()
 
 

--- a/mlem/core/metadata.py
+++ b/mlem/core/metadata.py
@@ -107,7 +107,7 @@ def load(
     path: str,
     repo: Optional[str] = None,
     rev: Optional[str] = None,
-    batch: Optional[int] = None,
+    batch_size: Optional[int] = None,
     follow_links: bool = True,
 ) -> Any:
     """Load python object saved by MLEM
@@ -127,10 +127,10 @@ def load(
         repo=repo,
         rev=rev,
         follow_links=follow_links,
-        load_value=batch is None,
+        load_value=batch_size is None,
     )
-    if isinstance(meta, DatasetMeta) and batch:
-        return meta.read_batch(batch)
+    if isinstance(meta, DatasetMeta) and batch_size:
+        return meta.read_batch(batch_size)
     return meta.get_value()
 
 

--- a/mlem/core/metadata.py
+++ b/mlem/core/metadata.py
@@ -124,7 +124,7 @@ def load(
         follow_links=follow_links,
         load_value=batch_size is None,
     )
-    if isinstance(meta, DatasetMeta) and batch_size:
+    if isinstance(meta, MlemDataset) and batch_size:
         return meta.read_batch(batch_size)
     return meta.get_value()
 

--- a/mlem/core/objects.py
+++ b/mlem/core/objects.py
@@ -677,9 +677,9 @@ class DatasetMeta(_WithArtifacts):
     def load_value(self):
         self.dataset = self.reader.read(self.relative_artifacts)
 
-    def read_batch(self, batch: int) -> Iterator[DatasetType]:
+    def read_batch(self, batch_size: int) -> Iterator[DatasetType]:
         assert isinstance(self.reader, DatasetReader)
-        return self.reader.read_batch(self.relative_artifacts, batch)
+        return self.reader.read_batch(self.relative_artifacts, batch_size)
 
     def get_value(self):
         return self.data

--- a/mlem/core/objects.py
+++ b/mlem/core/objects.py
@@ -14,6 +14,7 @@ from typing import (
     Dict,
     Generic,
     Iterable,
+    Iterator,
     List,
     Optional,
     Tuple,
@@ -675,6 +676,10 @@ class DatasetMeta(_WithArtifacts):
 
     def load_value(self):
         self.dataset = self.reader.read(self.relative_artifacts)
+
+    def read_batch(self, batch: int) -> Iterator[DatasetType]:
+        assert isinstance(self.reader, DatasetReader)
+        return self.reader.read_batch(self.relative_artifacts, batch)
 
     def get_value(self):
         return self.data

--- a/tests/cli/test_apply.py
+++ b/tests/cli/test_apply.py
@@ -53,14 +53,14 @@ def model_train_batch():
 def model_path_batch(model_train_batch, tmp_path_factory):
     path = os.path.join(tmp_path_factory.getbasetemp(), "saved-model")
     model, train = model_train_batch
-    save(model, path, tmp_sample_data=train, link=False)
+    save(model, path, sample_data=train, index=False)
     yield path
 
 
 @pytest.fixture
 def data_path_batch(model_train_batch, tmpdir_factory):
     temp_dir = str(tmpdir_factory.mktemp("saved-data") / "data")
-    save(model_train_batch[1], temp_dir, link=False)
+    save(model_train_batch[1], temp_dir, index=False)
     yield temp_dir
 
 
@@ -76,7 +76,7 @@ def test_apply_batch(runner, model_path_batch, data_path_batch):
                 "predict",
                 "-o",
                 path,
-                "--no-link",
+                "--no-index",
                 "-b",
                 "5",
             ],
@@ -129,7 +129,7 @@ def test_apply_batch_with_import(
                 "predict",
                 "-o",
                 path,
-                "--no-link",
+                "--no-index",
                 "--import",
                 "--it",
                 "pandas[csv]",

--- a/tests/cli/test_apply.py
+++ b/tests/cli/test_apply.py
@@ -4,9 +4,11 @@ import tempfile
 
 import pytest
 from numpy import ndarray
+from pandas import DataFrame
 from sklearn.datasets import load_iris
+from sklearn.tree import DecisionTreeClassifier
 
-from mlem.api import load
+from mlem.api import load, save
 from mlem.core.errors import MlemRootNotFound
 from mlem.runtime.client.base import HTTPClient
 from tests.conftest import MLEM_TEST_REPO, long, need_test_repo_auth
@@ -38,6 +40,52 @@ def test_apply(runner, model_path, data_path):
         assert isinstance(predictions, ndarray)
 
 
+@pytest.fixture
+def model_train_batch():
+    train, target = load_iris(return_X_y=True)
+    train = DataFrame(train)
+    train.columns = train.columns.astype(str)
+    model = DecisionTreeClassifier().fit(train, target)
+    return model, train
+
+
+@pytest.fixture
+def model_path_batch(model_train_batch, tmp_path_factory):
+    path = os.path.join(tmp_path_factory.getbasetemp(), "saved-model")
+    model, train = model_train_batch
+    save(model, path, tmp_sample_data=train, link=False)
+    yield path
+
+
+@pytest.fixture
+def data_path_batch(model_train_batch, tmpdir_factory):
+    temp_dir = str(tmpdir_factory.mktemp("saved-data") / "data")
+    save(model_train_batch[1], temp_dir, link=False)
+    yield temp_dir
+
+
+def test_apply_batch(runner, model_path_batch, data_path_batch):
+    with tempfile.TemporaryDirectory() as dir:
+        path = posixpath.join(dir, "data")
+        result = runner.invoke(
+            [
+                "apply",
+                model_path_batch,
+                data_path_batch,
+                "-m",
+                "predict",
+                "-o",
+                path,
+                "--no-link",
+                "-b",
+                "5",
+            ],
+        )
+        assert result.exit_code == 0, (result.output, result.exception)
+        predictions = load(path)
+        assert isinstance(predictions, ndarray)
+
+
 def test_apply_with_import(runner, model_meta_saved_single, tmp_path_factory):
     data_path = os.path.join(tmp_path_factory.getbasetemp(), "import_data")
     load_iris(return_X_y=True, as_frame=True)[0].to_csv(data_path, index=False)
@@ -62,6 +110,38 @@ def test_apply_with_import(runner, model_meta_saved_single, tmp_path_factory):
         assert result.exit_code == 0, (result.output, result.exception)
         predictions = load(path)
         assert isinstance(predictions, ndarray)
+
+
+def test_apply_batch_with_import(
+    runner, model_meta_saved_single, tmp_path_factory
+):
+    data_path = os.path.join(tmp_path_factory.getbasetemp(), "import_data")
+    load_iris(return_X_y=True, as_frame=True)[0].to_csv(data_path, index=False)
+
+    with tempfile.TemporaryDirectory() as dir:
+        path = posixpath.join(dir, "data")
+        result = runner.invoke(
+            [
+                "apply",
+                model_meta_saved_single.loc.uri,
+                data_path,
+                "-m",
+                "predict",
+                "-o",
+                path,
+                "--no-link",
+                "--import",
+                "--it",
+                "pandas[csv]",
+                "-b",
+                "2",
+            ],
+        )
+        assert result.exit_code == 1, (result.output, result.exception)
+        assert (
+            "Batch data loading is currently not supported for loading data on-the-fly"
+            in result.output
+        )
 
 
 def test_apply_no_output(runner, model_path, data_path):


### PR DESCRIPTION
### Context
Some datasets are large and rather than dealing them with one big block, we could split the data into chunks. This PR adds batch-reading support for data formats which provides the `chunksize` parameter using the Pandas API.

Related PRs: https://github.com/iterative/mlem/pull/206, https://github.com/iterative/mlem/pull/216

Supported formats:

- [x] CSV
- [x] JSON
- [x] Stata

### Modifications
- `mlem/cli/apply.py` - Added `batch` parameter when calling apply method - supports both importing data on/off-the-fly workflows
- `mlem/api/utils.py` - Added batch reading support when getting Dataset value
- `mlem/core/errors.py` - Added new errors `UnsupportedDatasetBatchLoadingType` and `UnsupportedDatasetBatchLoading` for batch-reading workflows
- `mlem/contrib/pandas.py` - Added batch-reading support for CSV, JSON, Stata data formats
- `tests/contrib/test_pandas.py` - Added tests for supported batch-reading data formats

**Which issue(s) this PR fixes:**
Fixes https://github.com/iterative/mlem/issues/23