### PR TITLE
fix for azure

### DIFF
--- a/mlem/utils/root.py
+++ b/mlem/utils/root.py
@@ -13,7 +13,12 @@ from mlem.core.errors import MlemRootNotFound
 def mlem_repo_exists(
     path: str, fs: AbstractFileSystem, raise_on_missing: bool = False
 ):
-    exists = fs.exists(posixpath.join(path, MLEM_DIR))
+    try:
+        exists = fs.exists(posixpath.join(path, MLEM_DIR))
+    except ValueError:
+        # some fsspec implementations throw ValueError because of
+        # wrong bucket/container names containing "."
+        exists = False
     if not exists and raise_on_missing:
         raise MlemRootNotFound(path, fs)
     return exists


### PR DESCRIPTION
some fsspec implementations throw ValueError because of wrong bucket/container names containing "."