### PR TITLE
Support combining batched prediction results on DatasetType

### DIFF
--- a/mlem/api/commands.py
+++ b/mlem/api/commands.py
@@ -16,7 +16,6 @@ from mlem.api.utils import (
 )
 from mlem.config import CONFIG_FILE_NAME, repo_config
 from mlem.constants import PREDICT_METHOD_NAME
-from mlem.core.dataset_type import DatasetAnalyzer
 from mlem.core.errors import (
     InvalidArgumentError,
     MlemObjectNotFound,
@@ -86,13 +85,14 @@ def apply(
         resolved_method = PREDICT_METHOD_NAME
     echo(EMOJI_APPLY + f"Applying `{resolved_method}` method...")
     if batch_size:
-        res: Any = None
+        res: Any = []
         for part in data:
             batch_dataset = get_dataset_value(part, batch_size)
             for chunk in batch_dataset:
                 preds = w.call_method(resolved_method, chunk.data)
-                dt = DatasetAnalyzer.analyze(preds)
-                res = dt.combine(res, preds)
+                dt = w.methods[resolved_method].returns
+                res.append(preds)
+        res = dt.combine(res)
     else:
         res = [
             w.call_method(resolved_method, get_dataset_value(part))

--- a/mlem/api/commands.py
+++ b/mlem/api/commands.py
@@ -90,8 +90,8 @@ def apply(
             batch_dataset = get_dataset_value(part, batch_size)
             for chunk in batch_dataset:
                 preds = w.call_method(resolved_method, chunk.data)
-                dt = w.methods[resolved_method].returns
                 res.append(preds)
+        dt = w.methods[resolved_method].returns
         res = dt.combine(res)
     else:
         res = [

--- a/mlem/api/commands.py
+++ b/mlem/api/commands.py
@@ -16,6 +16,7 @@ from mlem.api.utils import (
 )
 from mlem.config import CONFIG_FILE_NAME, repo_config
 from mlem.constants import PREDICT_METHOD_NAME
+from mlem.core.dataset_type import DatasetAnalyzer
 from mlem.core.errors import (
     InvalidArgumentError,
     MlemObjectNotFound,
@@ -85,12 +86,13 @@ def apply(
         resolved_method = PREDICT_METHOD_NAME
     echo(EMOJI_APPLY + f"Applying `{resolved_method}` method...")
     if batch_size:
-        res: Any = []
+        res: Any = None
         for part in data:
             batch_dataset = get_dataset_value(part, batch_size)
             for chunk in batch_dataset:
                 preds = w.call_method(resolved_method, chunk.data)
-                res += [*preds]  # TODO: merge results
+                dt = DatasetAnalyzer.analyze(preds)
+                res = dt.combine(res, preds)
     else:
         res = [
             w.call_method(resolved_method, get_dataset_value(part))

--- a/mlem/contrib/lightgbm.py
+++ b/mlem/contrib/lightgbm.py
@@ -73,6 +73,9 @@ class LightGBMDatasetType(
     def get_model(self, prefix: str = "") -> Type[BaseModel]:
         return self.inner.get_serializer().get_model(prefix)
 
+    def combine(self, batched_data: List[List[Any]]):
+        raise NotImplementedError
+
 
 class LightGBMDatasetWriter(DatasetWriter):
     type: ClassVar[str] = "lightgbm"

--- a/mlem/contrib/lightgbm.py
+++ b/mlem/contrib/lightgbm.py
@@ -73,7 +73,7 @@ class LightGBMDatasetType(
     def get_model(self, prefix: str = "") -> Type[BaseModel]:
         return self.inner.get_serializer().get_model(prefix)
 
-    def combine(self, batched_data: List[List[Any]]):
+    def combine(self, batched_data: List[List[Any]]) -> List[Any]:
         raise NotImplementedError
 
 

--- a/mlem/contrib/numpy.py
+++ b/mlem/contrib/numpy.py
@@ -101,6 +101,12 @@ class NumpyNdarrayType(
     def _abstract_shape(shape):
         return (None,) + shape[1:]
 
+    @staticmethod
+    def combine(original: np.ndarray, new: np.ndarray):
+        if original is None:
+            return new
+        return np.concatenate((original, new))
+
     @classmethod
     def process(cls, obj, **kwargs) -> DatasetType:
         return NumpyNdarrayType(

--- a/mlem/contrib/numpy.py
+++ b/mlem/contrib/numpy.py
@@ -83,7 +83,7 @@ class NumpyNumberType(
     def get_model(self, prefix: str = "") -> Type:
         return python_type_from_np_string_repr(self.dtype)
 
-    def combine(self, batched_data: Any):
+    def combine(self, batched_data: List[List[np.number]]) -> List[np.number]:
         raise NotImplementedError
 
 
@@ -108,7 +108,9 @@ class NumpyNdarrayType(
     def _abstract_shape(shape):
         return (None,) + shape[1:]
 
-    def combine(self, batched_data: List[List[np.ndarray]]):
+    def combine(
+        self, batched_data: List[List[np.ndarray]]
+    ) -> List[np.ndarray]:
         is_valid_type = all(
             self.is_object_valid(elem) for elem in batched_data
         )

--- a/mlem/contrib/pandas.py
+++ b/mlem/contrib/pandas.py
@@ -220,7 +220,7 @@ class _PandasDatasetType(
 
         return {"values": (instance.to_dict("records"))}
 
-    def combine(self, batched_data: List[List[Any]]):
+    def combine(self, batched_data: List[List[Any]]) -> List[Any]:
         raise NotImplementedError
 
 

--- a/mlem/contrib/pandas.py
+++ b/mlem/contrib/pandas.py
@@ -220,6 +220,9 @@ class _PandasDatasetType(
 
         return {"values": (instance.to_dict("records"))}
 
+    def combine(self, batched_data: List[List[Any]]):
+        raise NotImplementedError
+
 
 class SeriesType(_PandasDatasetType):
     """

--- a/mlem/contrib/torch.py
+++ b/mlem/contrib/torch.py
@@ -1,4 +1,4 @@
-from typing import Any, ClassVar, Iterator, Optional, Tuple
+from typing import Any, ClassVar, Iterator, List, Optional, Tuple
 
 import torch
 
@@ -76,7 +76,9 @@ class TorchTensorDatasetType(
             dtype=str(obj.dtype)[len(obj.dtype.__module__) + 1 :],
         )
 
-    def combine(self, batched_data: Any):
+    def combine(
+        self, batched_data: List[List[torch.Tensor]]
+    ) -> List[torch.Tensor]:
         raise NotImplementedError
 
 

--- a/mlem/contrib/torch.py
+++ b/mlem/contrib/torch.py
@@ -76,6 +76,9 @@ class TorchTensorDatasetType(
             dtype=str(obj.dtype)[len(obj.dtype.__module__) + 1 :],
         )
 
+    def combine(self, batched_data: Any):
+        raise NotImplementedError
+
 
 class TorchTensorWriter(DatasetWriter):
     type: ClassVar[str] = "torch"

--- a/mlem/contrib/xgboost.py
+++ b/mlem/contrib/xgboost.py
@@ -114,6 +114,9 @@ class DMatrixDatasetType(
     def get_model(self, prefix: str = "") -> Type[BaseModel]:
         raise NotImplementedError
 
+    def combine(self, batched_data: Any):
+        raise NotImplementedError
+
 
 class XGBoostModelIO(ModelIO):
     """

--- a/mlem/contrib/xgboost.py
+++ b/mlem/contrib/xgboost.py
@@ -114,7 +114,9 @@ class DMatrixDatasetType(
     def get_model(self, prefix: str = "") -> Type[BaseModel]:
         raise NotImplementedError
 
-    def combine(self, batched_data: Any):
+    def combine(
+        self, batched_data: List[List[xgboost.DMatrix]]
+    ) -> List[xgboost.DMatrix]:
         raise NotImplementedError
 
 

--- a/mlem/core/dataset_type.py
+++ b/mlem/core/dataset_type.py
@@ -14,6 +14,7 @@ from typing import (
     Sized,
     Tuple,
     Type,
+    TypeVar,
     Union,
 )
 
@@ -27,6 +28,8 @@ from mlem.core.errors import DeserializationError, SerializationError
 from mlem.core.hooks import Analyzer, Hook
 from mlem.core.requirements import Requirements, WithRequirements
 from mlem.utils.module import get_object_requirements
+
+T = TypeVar("T")
 
 
 class DatasetType(ABC, MlemABC, WithRequirements):
@@ -49,7 +52,7 @@ class DatasetType(ABC, MlemABC, WithRequirements):
             )
 
     @abstractmethod
-    def combine(self, batched_data: List[List[Any]]):
+    def combine(self, batched_data: List[List[T]]) -> List[T]:
         raise NotImplementedError
 
     @abstractmethod
@@ -112,7 +115,7 @@ class UnspecifiedDatasetType(DatasetType, DatasetSerializer):
     def get_model(self, prefix: str = "") -> Type[BaseModel]:
         raise NotImplementedError
 
-    def combine(self, batched_data: List[List[Any]]):
+    def combine(self, batched_data: List[List[Any]]) -> List[Any]:
         raise NotImplementedError
 
 
@@ -203,7 +206,7 @@ class PrimitiveType(DatasetType, DatasetHook, DatasetSerializer):
     def get_model(self, prefix: str = "") -> Type[BaseModel]:
         return self.to_type
 
-    def combine(self, batched_data: List[List[Any]]):
+    def combine(self, batched_data: List[List[Any]]) -> List[Any]:
         raise NotImplementedError
 
 
@@ -273,7 +276,7 @@ class ListDatasetType(DatasetType, DatasetSerializer):
             __root__=(List[self.dtype.get_serializer().get_model(subname)], ...),  # type: ignore
         )
 
-    def combine(self, batched_data: List[List[Any]]):
+    def combine(self, batched_data: List[List[Any]]) -> List[Any]:
         raise NotImplementedError
 
 
@@ -371,7 +374,7 @@ class _TupleLikeDatasetType(DatasetType, DatasetSerializer):
             ),
         )
 
-    def combine(self, batched_data: List[List[Any]]):
+    def combine(self, batched_data: List[List[Any]]) -> List[Any]:
         raise NotImplementedError
 
 
@@ -550,7 +553,7 @@ class DictDatasetType(DatasetType, DatasetSerializer, DatasetHook):
         }
         return create_model(prefix + "DictDataset", **kwargs)  # type: ignore
 
-    def combine(self, batched_data: List[List[Any]]):
+    def combine(self, batched_data: List[List[Any]]) -> List[Any]:
         raise NotImplementedError
 
 

--- a/mlem/core/dataset_type.py
+++ b/mlem/core/dataset_type.py
@@ -48,6 +48,10 @@ class DatasetType(ABC, MlemABC, WithRequirements):
                 f"given dataset is of type: {type(obj)}, expected: {exp_type}"
             )
 
+    @staticmethod
+    def combine(original: Any, new: Any):
+        raise NotImplementedError
+
     @abstractmethod
     def get_requirements(self) -> Requirements:
         return get_object_requirements(self)

--- a/mlem/core/dataset_type.py
+++ b/mlem/core/dataset_type.py
@@ -48,8 +48,8 @@ class DatasetType(ABC, MlemABC, WithRequirements):
                 f"given dataset is of type: {type(obj)}, expected: {exp_type}"
             )
 
-    @staticmethod
-    def combine(original: Any, new: Any):
+    @abstractmethod
+    def combine(self, batched_data: List[List[Any]]):
         raise NotImplementedError
 
     @abstractmethod
@@ -110,6 +110,9 @@ class UnspecifiedDatasetType(DatasetType, DatasetSerializer):
         raise NotImplementedError
 
     def get_model(self, prefix: str = "") -> Type[BaseModel]:
+        raise NotImplementedError
+
+    def combine(self, batched_data: List[List[Any]]):
         raise NotImplementedError
 
 
@@ -200,6 +203,9 @@ class PrimitiveType(DatasetType, DatasetHook, DatasetSerializer):
     def get_model(self, prefix: str = "") -> Type[BaseModel]:
         return self.to_type
 
+    def combine(self, batched_data: List[List[Any]]):
+        raise NotImplementedError
+
 
 class PrimitiveWriter(DatasetWriter):
     type: ClassVar[str] = "primitive"
@@ -266,6 +272,9 @@ class ListDatasetType(DatasetType, DatasetSerializer):
             prefix + "ListDataset",
             __root__=(List[self.dtype.get_serializer().get_model(subname)], ...),  # type: ignore
         )
+
+    def combine(self, batched_data: List[List[Any]]):
+        raise NotImplementedError
 
 
 class ListWriter(DatasetWriter):
@@ -361,6 +370,9 @@ class _TupleLikeDatasetType(DatasetType, DatasetSerializer):
                 ...,
             ),
         )
+
+    def combine(self, batched_data: List[List[Any]]):
+        raise NotImplementedError
 
 
 def _check_type_and_size(obj, dtype, size, exc_type):
@@ -537,6 +549,9 @@ class DictDatasetType(DatasetType, DatasetSerializer, DatasetHook):
             for k, v in self.item_types.items()
         }
         return create_model(prefix + "DictDataset", **kwargs)  # type: ignore
+
+    def combine(self, batched_data: List[List[Any]]):
+        raise NotImplementedError
 
 
 class DictWriter(DatasetWriter):

--- a/mlem/core/errors.py
+++ b/mlem/core/errors.py
@@ -89,6 +89,10 @@ class UnsupportedDatasetBatchLoading(MlemError):
     """Thrown if batch loading of dataset is called for import workflow"""
 
 
+class InvalidDatatypeForBatchLoading(MlemError):
+    """Thrown if batch loading of dataset has incorrect types"""
+
+
 class WrongMethodError(ValueError, MlemError):
     """Thrown if wrong method name for model is provided"""
 

--- a/mlem/runtime/interface.py
+++ b/mlem/runtime/interface.py
@@ -25,7 +25,7 @@ class InterfaceDescriptor(BaseModel):
 
 class Interface(ABC, MlemABC):
     """Base class for runtime interfaces.
-    Describes a set of methods togerher with their signatures (arguments
+    Describes a set of methods together with their signatures (arguments
     and return type) and executors - actual python callables to be run
     when the method is invoked. Used to setup `Server`"""
 

--- a/tests/cli/test_apply.py
+++ b/tests/cli/test_apply.py
@@ -9,7 +9,7 @@ from sklearn.datasets import load_iris
 from sklearn.tree import DecisionTreeClassifier
 
 from mlem.api import load, save
-from mlem.core.dataset_type import ListDatasetType
+from mlem.contrib.numpy import NumpyNdarrayType
 from mlem.core.errors import MlemRootNotFound
 from mlem.core.metadata import load_meta
 from mlem.core.objects import MlemDataset
@@ -89,9 +89,9 @@ def test_apply_batch(runner, model_path_batch, data_path_batch):
         predictions_meta = load_meta(
             path, load_value=True, force_type=MlemDataset
         )
-        assert isinstance(predictions_meta.dataset, ListDatasetType)
+        assert isinstance(predictions_meta.dataset, NumpyNdarrayType)
         predictions = predictions_meta.get_value()
-        assert isinstance(predictions, list)
+        assert isinstance(predictions, ndarray)
 
 
 def test_apply_with_import(runner, model_meta_saved_single, tmp_path_factory):

--- a/tests/runtime/test_interface.py
+++ b/tests/runtime/test_interface.py
@@ -28,7 +28,7 @@ class Container(DatasetType):
     def get_writer(self, **kwargs) -> DatasetWriter:
         raise NotImplementedError()
 
-    def combine(self, batched_data: List[List[Any]]):
+    def combine(self, batched_data: List[List[Any]]) -> List[Any]:
         raise NotImplementedError
 
 

--- a/tests/runtime/test_interface.py
+++ b/tests/runtime/test_interface.py
@@ -1,4 +1,4 @@
-from typing import Any, ClassVar
+from typing import Any, ClassVar, List
 
 import pytest
 
@@ -27,6 +27,9 @@ class Container(DatasetType):
 
     def get_writer(self, **kwargs) -> DatasetWriter:
         raise NotImplementedError()
+
+    def combine(self, batched_data: List[List[Any]]):
+        raise NotImplementedError
 
 
 @pytest.fixture


### PR DESCRIPTION
### Context
A bug was introduced in https://github.com/iterative/mlem/pull/221, where approach to combining prediction results incorrectly assumed type to be numpy array. This PR utilizes `DatasetAnalyzer` to first determine the type of the results prior to combining them, since the same model can output different data types.

### Modifications
- `mlem/api/commands.py` - Interpret data type prior to combining prediction results
- `mlem/contrib/numpy.py` - Add support for combining batch reading prediction results for nd.array

**Which issue(s) this PR fixes:**
Fixes https://github.com/iterative/mlem/issues/257