### PR TITLE
add core section

### DIFF
--- a/mlem/cli/apply.py
+++ b/mlem/cli/apply.py
@@ -25,9 +25,9 @@ from mlem.core.errors import UnsupportedDatasetBatchLoading
 from mlem.core.import_objects import ImportHook
 from mlem.core.metadata import load_meta
 from mlem.core.objects import MlemDataset, MlemModel
-from mlem.ext import list_implementations
 from mlem.runtime.client import Client
 from mlem.ui import set_echo
+from mlem.utils.entrypoints import list_implementations
 
 
 @mlem_command("apply", section="runtime")

--- a/mlem/cli/dev.py
+++ b/mlem/cli/dev.py
@@ -1,8 +1,12 @@
 from typer import Argument, Typer
 
 from mlem.cli.main import MlemGroupSection, app, mlem_command
-from mlem.ext import MLEM_ENTRY_POINT, find_implementations, load_entrypoints
 from mlem.ui import echo
+from mlem.utils.entrypoints import (
+    MLEM_ENTRY_POINT,
+    find_implementations,
+    load_entrypoints,
+)
 
 dev = Typer(name="dev", cls=MlemGroupSection("common"), hidden=True)
 app.add_typer(dev)

--- a/mlem/cli/import_object.py
+++ b/mlem/cli/import_object.py
@@ -11,7 +11,7 @@ from mlem.cli.main import (
     option_target_repo,
 )
 from mlem.core.import_objects import ImportHook
-from mlem.ext import list_implementations
+from mlem.utils.entrypoints import list_implementations
 
 
 @mlem_command("import", section="object")

--- a/mlem/cli/package.py
+++ b/mlem/cli/package.py
@@ -13,7 +13,7 @@ from mlem.cli.main import (
 )
 from mlem.core.metadata import load_meta
 from mlem.core.objects import MlemModel, MlemPackager
-from mlem.ext import list_implementations
+from mlem.utils.entrypoints import list_implementations
 
 
 @mlem_command("pack", section="runtime")

--- a/mlem/cli/serve.py
+++ b/mlem/cli/serve.py
@@ -13,8 +13,8 @@ from mlem.cli.main import (
 )
 from mlem.core.metadata import load_meta
 from mlem.core.objects import MlemModel
-from mlem.ext import list_implementations
 from mlem.runtime.server import Server
+from mlem.utils.entrypoints import list_implementations
 
 
 @mlem_command("serve", section="runtime")

--- a/mlem/cli/types.py
+++ b/mlem/cli/types.py
@@ -6,8 +6,8 @@ from typer import Argument
 from mlem.cli.main import mlem_command
 from mlem.core.base import MlemABC, load_impl_ext
 from mlem.core.objects import MlemObject
-from mlem.ext import list_implementations
 from mlem.ui import EMOJI_BASE, bold, color, echo
+from mlem.utils.entrypoints import list_implementations
 
 
 def explain_type(cls: Type[BaseModel], prefix="", force_not_req=False):

--- a/mlem/config.py
+++ b/mlem/config.py
@@ -2,15 +2,17 @@
 Configuration management for MLEM
 """
 import posixpath
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Type, TypeVar, Union, overload
 
 import yaml
 from fsspec import AbstractFileSystem
 from fsspec.implementations.local import LocalFileSystem
-from pydantic import BaseSettings, Extra, Field, parse_obj_as
+from pydantic import BaseSettings, Field, parse_obj_as, root_validator
 from pydantic.env_settings import InitSettingsSource
 
 from mlem.constants import MLEM_DIR
+from mlem.core.errors import UnknownConfigSection
+from mlem.utils.entrypoints import MLEM_CONFIG_ENTRY_POINT, load_entrypoints
 
 CONFIG_FILE_NAME = "config.yaml"
 
@@ -61,7 +63,6 @@ class MlemConfigBase(BaseSettings):
         env_prefix = "mlem_"
         env_file_encoding = "utf-8"
         section: Optional[str] = None
-        extra = Extra.allow
 
         @classmethod
         def customise_sources(
@@ -78,32 +79,47 @@ class MlemConfigBase(BaseSettings):
                 file_secret_settings,
             )
 
+    @root_validator(pre=True)
+    def ignore_case(
+        cls, value: Any
+    ):  # pylint: disable=no-self-argument  # noqa: B902
+        new_value = {}
+        if isinstance(value, dict):
+            for key, val in value.items():
+                if key.upper() in cls.__fields__:
+                    key = key.upper()
+                if key.lower() in cls.__fields__:
+                    key = key.lower()
+                new_value[key] = val
+        return new_value
+
 
 class MlemConfig(MlemConfigBase):
     """Base Mlem Config"""
 
+    class Config:
+        section = "core"
+
     GITHUB_USERNAME: Optional[str] = Field(default=None, env="GITHUB_USERNAME")
     GITHUB_TOKEN: Optional[str] = Field(default=None, env="GITHUB_TOKEN")
-    ADDITIONAL_EXTENSIONS_RAW: str = Field(
-        default="", env="MLEM_ADDITIONAL_EXTENSIONS"
-    )
+    ADDITIONAL_EXTENSIONS: str = Field(default="")
     AUTOLOAD_EXTS: bool = True
     LOG_LEVEL: str = "INFO"
     DEBUG: bool = False
     NO_ANALYTICS: bool = False
     TESTS: bool = False
-    DEFAULT_STORAGE: Dict = {}
+    STORAGE: Dict = {}
     INDEX: Dict = {}
-    DEFAULT_EXTERNAL: bool = False
+    EXTERNAL: bool = False
     EMOJIS: bool = True
 
     @property
-    def default_storage(self):
+    def storage(self):
         from mlem.core.artifacts import LOCAL_STORAGE, Storage
 
-        if not self.DEFAULT_STORAGE:
+        if not self.STORAGE:
             return LOCAL_STORAGE
-        s = parse_obj_as(Storage, self.DEFAULT_STORAGE)
+        s = parse_obj_as(Storage, self.STORAGE)
         return s
 
     @property
@@ -115,22 +131,61 @@ class MlemConfig(MlemConfigBase):
         return parse_obj_as(Index, self.INDEX)
 
     @property
-    def ADDITIONAL_EXTENSIONS(self) -> List[str]:
-        if self.ADDITIONAL_EXTENSIONS_RAW == "":
+    def additional_extensions(self) -> List[str]:
+        if self.ADDITIONAL_EXTENSIONS == "":
             return []
-        return (
-            self.ADDITIONAL_EXTENSIONS_RAW.split(  # pylint: disable=no-member
-                ","
-            )
+        return self.ADDITIONAL_EXTENSIONS.split(  # pylint: disable=no-member
+            ","
         )
 
 
 CONFIG = MlemConfig()
 
 
+def get_config_cls(section: str) -> Type[MlemConfigBase]:
+    try:
+        return load_entrypoints(MLEM_CONFIG_ENTRY_POINT)[section].ep.load()
+    except KeyError as e:
+        raise UnknownConfigSection(section) from e
+
+
+T = TypeVar("T", bound=MlemConfigBase)
+
+
+@overload
 def repo_config(
-    repo: str, fs: Optional[AbstractFileSystem] = None
+    repo: str,
+    fs: Optional[AbstractFileSystem] = None,
+    section: Type[MlemConfig] = MlemConfig,
 ) -> MlemConfig:
+    ...
+
+
+@overload
+def repo_config(
+    repo: str, fs: Optional[AbstractFileSystem] = None, section: str = ...
+) -> MlemConfigBase:
+    ...
+
+
+@overload
+def repo_config(
+    repo: str,
+    fs: Optional[AbstractFileSystem] = None,
+    section: Type[T] = ...,
+) -> T:
+    ...
+
+
+def repo_config(
+    repo: str,
+    fs: Optional[AbstractFileSystem] = None,
+    section: Union[Type[MlemConfigBase], str] = MlemConfig,
+) -> MlemConfigBase:
+    if isinstance(section, str):
+        cls = get_config_cls(section)
+    else:
+        cls = section
     if fs is None:
         fs = LocalFileSystem()
-    return MlemConfig(config_path=repo, config_fs=fs)
+    return cls(config_path=repo, config_fs=fs)

--- a/mlem/contrib/pandas.py
+++ b/mlem/contrib/pandas.py
@@ -111,7 +111,7 @@ def need_string_value(dtype):
 
 
 class PandasConfig(MlemConfigBase):
-    DEFAULT_FORMAT: str = "csv"
+    default_format: str = "csv"
 
     class Config:
         section = "pandas"
@@ -256,7 +256,7 @@ class SeriesType(_PandasDatasetType):
         return super().serialize(pd.DataFrame(instance))["values"]
 
     def get_writer(self, **kwargs) -> "DatasetWriter":
-        fmt = PANDAS_CONFIG.DEFAULT_FORMAT
+        fmt = PANDAS_CONFIG.default_format
         if "format" in kwargs:
             fmt = kwargs["format"]
         elif "filename" in kwargs:
@@ -325,7 +325,7 @@ class DataFrameType(_PandasDatasetType):
         )
 
     def get_writer(self, **kwargs) -> "DatasetWriter":
-        fmt = PANDAS_CONFIG.DEFAULT_FORMAT
+        fmt = PANDAS_CONFIG.default_format
         if "format" in kwargs:
             fmt = kwargs["format"]
         elif "filename" in kwargs:

--- a/mlem/core/base.py
+++ b/mlem/core/base.py
@@ -38,7 +38,9 @@ def load_impl_ext(
     (because default for PolyModel._get_alias() is module_name.class_name).
     If that fails, we try to find implementation from entrypoints
     """
-    from mlem.ext import load_entrypoints  # circular dependencies
+    from mlem.utils.entrypoints import (  # circular dependencies
+        load_entrypoints,
+    )
 
     if type_name is not None and "." in type_name:
         try:

--- a/mlem/core/errors.py
+++ b/mlem/core/errors.py
@@ -137,3 +137,9 @@ class UnknownImplementation(MlemError):
         self.abs_name = abs_name
         self.type_name = type_name
         super().__init__(f"Unknown {abs_name} implementation: {type_name}")
+
+
+class UnknownConfigSection(MlemError):
+    def __init__(self, section: str):
+        self.section = section
+        super().__init__(f'Unknown config section "{section}"')

--- a/mlem/core/objects.py
+++ b/mlem/core/objects.py
@@ -252,7 +252,7 @@ class MlemObject(MlemABC):
     ) -> Tuple[Location, bool]:
         """Parse arguments for .dump and bind meta"""
         if external is None:
-            external = CONFIG.DEFAULT_EXTERNAL
+            external = CONFIG.EXTERNAL
         # by default we index only external non-orphan objects
         if index is None:
             index = True
@@ -562,9 +562,7 @@ class _WithArtifacts(ABC, MlemObject):
         if not self.location.fs or isinstance(
             self.location.fs, LocalFileSystem
         ):
-            return CONFIG.default_storage.relative(
-                self.location.fs, self.dirname
-            )
+            return CONFIG.storage.relative(self.location.fs, self.dirname)
         return FSSpecStorage.from_fs_path(self.location.fs, self.dirname)
 
     def get_artifacts(self):

--- a/mlem/ext.py
+++ b/mlem/ext.py
@@ -2,22 +2,13 @@
 Classes and functions to load and work with out-of-the-box included extensions
 as well with the custom ones
 """
-import glob
 import importlib
 import logging
-import os
 import sys
-from dataclasses import dataclass
-from functools import lru_cache
-from inspect import isabstract
 from types import ModuleType
-from typing import Callable, Dict, List, Optional, Type, Union
-
-import entrypoints
+from typing import Callable, Dict, List, Union
 
 from mlem.config import CONFIG
-from mlem.core.base import MlemABC, load_impl_ext
-from mlem.core.objects import MlemObject
 from mlem.utils.importing import (
     import_module,
     module_importable,
@@ -25,8 +16,6 @@ from mlem.utils.importing import (
 )
 
 logger = logging.getLogger(__name__)
-
-MLEM_ENTRY_POINT = "mlem.contrib"
 
 
 class Extension:
@@ -170,7 +159,7 @@ class ExtensionLoader:
 
         cls._setup_import_hook(for_hook)
 
-        for mod in CONFIG.ADDITIONAL_EXTENSIONS:
+        for mod in CONFIG.additional_extensions:
             cls.load(mod)
 
     @classmethod
@@ -253,107 +242,6 @@ def load_extensions(*exts: str):
     """
     for ext in exts:
         ExtensionLoader.load(ext)
-
-
-@dataclass
-class Entrypoint:
-    name: Optional[str]
-    abs_name: str
-    ep: entrypoints.EntryPoint
-
-    @classmethod
-    def from_entrypoint(cls, ep: entrypoints.EntryPoint):
-        if "." not in ep.name:
-            return cls(name=None, ep=ep, abs_name=ep.name)
-        abs_name, name = ep.name.split(".", maxsplit=2)
-        return cls(name=name, ep=ep, abs_name=abs_name)
-
-    @property
-    def entry(self):
-        name = f".{self.name}" if self.name else ""
-        return f"{self.abs_name}{name} = {self.ep.module_name}:{self.ep.object_name}"
-
-
-@lru_cache()
-def load_entrypoints() -> Dict[str, Entrypoint]:
-    """Load MLEM entrypoints defined in setup.py
-    These entrypoints are used later to find out which extensions to load
-    when a particular object requires them upon it's deserialision
-    """
-    eps = entrypoints.get_group_named(MLEM_ENTRY_POINT)
-    return {k: Entrypoint.from_entrypoint(ep) for k, ep in eps.items()}
-
-
-def list_implementations(
-    base_class: Union[str, Type[MlemABC]],
-    meta_subtype: Type[MlemObject] = None,
-) -> List[str]:
-    if isinstance(base_class, type) and issubclass(base_class, MlemABC):
-        abs_name = base_class.abs_name
-    if base_class == "meta" and meta_subtype is not None:
-        base_class = meta_subtype.object_type
-        abs_name = "meta"
-    if isinstance(base_class, str):
-        abs_name = base_class
-        try:
-            base_class = MlemABC.abs_types[abs_name]
-        except KeyError:
-            base_class = load_impl_ext(abs_name, None)
-    eps = {
-        e.name
-        for e in load_entrypoints().values()
-        if e.abs_name == abs_name and e.name is not None
-    }
-    eps.update(base_class.non_abstract_subtypes())
-    return list(eps)
-
-
-def find_implementations(root_module_name: str = MLEM_ENTRY_POINT):
-    """Generates dict with MLEM entrypoints which should appear in setup.py.
-    Can be used by plugin developers to check if they populated all existing
-    entrypoints in setup.py
-    """
-    root_module = import_module(root_module_name)
-    assert root_module.__file__ is not None
-    path = os.path.dirname(root_module.__file__)
-
-    impls = {}
-    for pyfile in glob.glob(os.path.join(path, "**", "*.py"), recursive=True):
-        module_name = (
-            root_module_name
-            + "."
-            + os.path.relpath(pyfile, path)[: -len(".py")].replace(os.sep, ".")
-        )
-        if module_name.endswith(".__init__"):
-            module_name = module_name[: -len(".__init__")]
-        try:
-            module = import_module(module_name)
-        except ImportError as e:
-            print(
-                f"Cannot import module {module_name}: {e.__class__} {e.args}"
-            )
-            continue
-
-        for obj in module.__dict__.values():
-
-            # pylint: disable=too-many-boolean-expressions
-            if (
-                isinstance(obj, type)
-                and obj.__module__ == module.__name__
-                and issubclass(obj, MlemABC)
-                and not isabstract(obj)
-                and hasattr(obj, "abs_name")
-            ):
-                impls[obj] = f"{obj.__module__}:{obj.__name__}"
-
-    return {
-        MLEM_ENTRY_POINT: [
-            f"{obj.abs_name}.{obj.__get_alias__()} = {name}"
-            if not obj.__is_root__
-            else f"{obj.abs_name} = {name}"
-            for obj, name in impls.items()
-        ]
-    }
 
 
 # Copyright 2019 Zyfra

--- a/mlem/utils/entrypoints.py
+++ b/mlem/utils/entrypoints.py
@@ -1,0 +1,122 @@
+import glob
+import logging
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+from inspect import isabstract
+from typing import TYPE_CHECKING, Dict, List, Optional, Type, Union
+
+import entrypoints
+
+from mlem.core.base import MlemABC, load_impl_ext
+from mlem.utils.importing import import_module
+
+if TYPE_CHECKING:
+    from mlem.core.objects import MlemObject
+
+
+logger = logging.getLogger(__name__)
+
+MLEM_ENTRY_POINT = "mlem.contrib"
+MLEM_CONFIG_ENTRY_POINT = "mlem.config"
+
+
+@dataclass
+class Entrypoint:
+    name: Optional[str]
+    abs_name: str
+    ep: entrypoints.EntryPoint
+
+    @classmethod
+    def from_entrypoint(cls, ep: entrypoints.EntryPoint):
+        if "." not in ep.name:
+            return cls(name=None, ep=ep, abs_name=ep.name)
+        abs_name, name = ep.name.split(".", maxsplit=2)
+        return cls(name=name, ep=ep, abs_name=abs_name)
+
+    @property
+    def entry(self):
+        name = f".{self.name}" if self.name else ""
+        return f"{self.abs_name}{name} = {self.ep.module_name}:{self.ep.object_name}"
+
+
+@lru_cache()
+def load_entrypoints(domain: str = MLEM_ENTRY_POINT) -> Dict[str, Entrypoint]:
+    """Load MLEM entrypoints defined in setup.py
+    These entrypoints are used later to find out which extensions to load
+    when a particular object requires them upon it's deserialision
+    """
+    eps = entrypoints.get_group_named(domain)
+    return {k: Entrypoint.from_entrypoint(ep) for k, ep in eps.items()}
+
+
+def list_implementations(
+    base_class: Union[str, Type[MlemABC]],
+    meta_subtype: Type["MlemObject"] = None,
+) -> List[str]:
+    if isinstance(base_class, type) and issubclass(base_class, MlemABC):
+        abs_name = base_class.abs_name
+    if base_class == "meta" and meta_subtype is not None:
+        base_class = meta_subtype.object_type
+        abs_name = "meta"
+    if isinstance(base_class, str):
+        abs_name = base_class
+        try:
+            base_class = MlemABC.abs_types[abs_name]
+        except KeyError:
+            base_class = load_impl_ext(abs_name, None)
+    eps = {
+        e.name
+        for e in load_entrypoints().values()
+        if e.abs_name == abs_name and e.name is not None
+    }
+    eps.update(base_class.non_abstract_subtypes())
+    return list(eps)
+
+
+def find_implementations(root_module_name: str = MLEM_ENTRY_POINT):
+    """Generates dict with MLEM entrypoints which should appear in setup.py.
+    Can be used by plugin developers to check if they populated all existing
+    entrypoints in setup.py
+    """
+    root_module = import_module(root_module_name)
+    assert root_module.__file__ is not None
+    path = os.path.dirname(root_module.__file__)
+
+    impls = {}
+    for pyfile in glob.glob(os.path.join(path, "**", "*.py"), recursive=True):
+        module_name = (
+            root_module_name
+            + "."
+            + os.path.relpath(pyfile, path)[: -len(".py")].replace(os.sep, ".")
+        )
+        if module_name.endswith(".__init__"):
+            module_name = module_name[: -len(".__init__")]
+        try:
+            module = import_module(module_name)
+        except ImportError as e:
+            print(
+                f"Cannot import module {module_name}: {e.__class__} {e.args}"
+            )
+            continue
+
+        for obj in module.__dict__.values():
+
+            # pylint: disable=too-many-boolean-expressions
+            if (
+                isinstance(obj, type)
+                and obj.__module__ == module.__name__
+                and issubclass(obj, MlemABC)
+                and not isabstract(obj)
+                and hasattr(obj, "abs_name")
+            ):
+                impls[obj] = f"{obj.__module__}:{obj.__name__}"
+
+    return {
+        MLEM_ENTRY_POINT: [
+            f"{obj.abs_name}.{obj.__get_alias__()} = {name}"
+            if not obj.__is_root__
+            else f"{obj.abs_name} = {name}"
+            for obj, name in impls.items()
+        ]
+    }

--- a/mlem/utils/module.py
+++ b/mlem/utils/module.py
@@ -7,6 +7,7 @@ import re
 import sys
 import threading
 import warnings
+from collections import defaultdict
 from functools import lru_cache, wraps
 from pickle import PickleError
 from types import FunctionType, LambdaType, MethodType, ModuleType
@@ -454,7 +455,7 @@ class RequirementAnalyzer(dill.Pickler):
 
     add_closure_for = [
         FunctionType,
-        MethodType,
+        MethodType,  # from dill 0.3.5 it is absent, need to dig deeper
         staticmethod,
         classmethod,
         LambdaType,
@@ -463,6 +464,7 @@ class RequirementAnalyzer(dill.Pickler):
         {
             t: add_closure_inspection(dill.Pickler.dispatch[t])
             for t in add_closure_for
+            if t in dill.Pickler.dispatch
         }
     )
     dispatch[TypeType] = save_type_with_classvars
@@ -474,6 +476,7 @@ class RequirementAnalyzer(dill.Pickler):
         self.framer.write = self.skip_write
         self.write = self.skip_write
         self.memoize = self.skip_write
+        self.memo = defaultdict(lambda: None)
         self.seen = set()
         self._modules = set()
 

--- a/setup.py
+++ b/setup.py
@@ -160,6 +160,10 @@ setup_args = dict(  # noqa: C408
             "server.rmq = mlem.contrib.rabbitmq:RabbitMQServer",
             "storage.dvc = mlem.contrib.dvc:DVCStorage",
         ],
+        "mlem.config": [
+            "core = mlem.config:MlemConfig",
+            "pandas = mlem.contrib.pandas:PandasConfig",
+        ],
     },
     zip_safe=False,
 )

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -47,8 +47,9 @@ def test_set_get_validation(runner: Runner, mlem_repo):
     )
 
     assert result.exit_code == 1
-    assert isinstance(
-        result.exception, ValidationError
+    assert (
+        isinstance(result.exception, ValidationError)
+        or "extra fields not permitted" in result.output
     ), traceback.format_exception(
         type(result.exception),
         result.exception,

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -1,3 +1,5 @@
+import traceback
+
 from pydantic import ValidationError
 
 from mlem.config import repo_config
@@ -45,7 +47,13 @@ def test_set_get_validation(runner: Runner, mlem_repo):
     )
 
     assert result.exit_code == 1
-    assert isinstance(result.exception, ValidationError)
+    assert isinstance(
+        result.exception, ValidationError
+    ), traceback.format_exception(
+        type(result.exception),
+        result.exception,
+        result.exception.__traceback__,
+    )
 
     result = runner.invoke(
         f"config set nonexisting json --repo {mlem_repo}".split()

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -61,7 +61,14 @@ def test_set_get_validation(runner: Runner, mlem_repo):
     )
 
     assert result.exit_code == 1
-    assert isinstance(result.exception, MlemError)
+    assert (
+        isinstance(result.exception, MlemError)
+        or "[name] should contain at least one dot" in result.output
+    ), traceback.format_exception(
+        type(result.exception),
+        result.exception,
+        result.exception.__traceback__,
+    )
 
     result = runner.invoke(
         f"config set core.nonexisting json --repo {mlem_repo} --no-validate".split()

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -1,5 +1,8 @@
+from pydantic import ValidationError
+
 from mlem.config import repo_config
 from mlem.contrib.pandas import PandasConfig
+from mlem.core.errors import MlemError
 from tests.cli.conftest import Runner
 
 
@@ -11,7 +14,7 @@ def test_set_get(runner: Runner, mlem_repo):
     assert result.exit_code == 0, result.exception
 
     result = runner.invoke(
-        f"config set additional_extensions_raw ext1 --repo {mlem_repo}".split()
+        f"config set core.additional_extensions ext1 --repo {mlem_repo}".split()
     )
 
     assert result.exit_code == 0, result.exception
@@ -24,11 +27,35 @@ def test_set_get(runner: Runner, mlem_repo):
     assert result.stdout.strip() == "json"
 
     result = runner.invoke(
-        f"config get additional_extensions_raw --repo {mlem_repo}".split()
+        f"config get core.additional_extensions --repo {mlem_repo}".split()
     )
 
     assert result.exit_code == 0, result.exception
     assert result.stdout.strip() == "ext1"
 
-    assert repo_config(mlem_repo).ADDITIONAL_EXTENSIONS == ["ext1"]
-    assert PandasConfig(config_path=mlem_repo).DEFAULT_FORMAT == "json"
+    assert repo_config(mlem_repo).additional_extensions == ["ext1"]
+    assert (
+        repo_config(mlem_repo, section=PandasConfig).default_format == "json"
+    )
+
+
+def test_set_get_validation(runner: Runner, mlem_repo):
+    result = runner.invoke(
+        f"config set core.nonexisting json --repo {mlem_repo}".split()
+    )
+
+    assert result.exit_code == 1
+    assert isinstance(result.exception, ValidationError)
+
+    result = runner.invoke(
+        f"config set nonexisting json --repo {mlem_repo}".split()
+    )
+
+    assert result.exit_code == 1
+    assert isinstance(result.exception, MlemError)
+
+    result = runner.invoke(
+        f"config set core.nonexisting json --repo {mlem_repo} --no-validate".split()
+    )
+
+    assert result.exit_code == 0

--- a/tests/contrib/test_pandas.py
+++ b/tests/contrib/test_pandas.py
@@ -522,7 +522,7 @@ def test_import_data_csv_remote(s3_tmp_path, s3_storage_fs, write_csv):
 def test_default_format(set_mlem_repo_root, df_type):
     set_mlem_repo_root("pandas", __file__)
     config = PandasConfig()
-    assert config.DEFAULT_FORMAT == "json"
+    assert config.default_format == "json"
 
 
 def test_dataframe():

--- a/tests/resources/storage/.mlem/config.yaml
+++ b/tests/resources/storage/.mlem/config.yaml
@@ -1,4 +1,5 @@
-ADDITIONAL_EXTENSIONS_RAW: ext1
-default_storage:
-  type: fsspec
-  uri: s3://somebucket
+core:
+  ADDITIONAL_EXTENSIONS: ext1
+  storage:
+    type: fsspec
+    uri: s3://somebucket

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,14 +10,14 @@ from tests.conftest import long
 def test_loading_storage(set_mlem_repo_root):
     set_mlem_repo_root("storage")
     config = MlemConfig()
-    assert config.ADDITIONAL_EXTENSIONS == ["ext1"]
-    assert config.default_storage == FSSpecStorage(uri="s3://somebucket")
+    assert config.additional_extensions == ["ext1"]
+    assert config.storage == FSSpecStorage(uri="s3://somebucket")
 
 
 def test_loading_empty(set_mlem_repo_root):
     set_mlem_repo_root("empty")
     config = MlemConfig()
-    assert isinstance(config.default_storage, LocalStorage)
+    assert isinstance(config.storage, LocalStorage)
 
 
 @long
@@ -26,5 +26,5 @@ def test_loading_remote(s3_tmp_path, s3_storage_fs):
     fs, path = get_fs(repo)
     path = posixpath.join(path, MLEM_DIR, CONFIG_FILE_NAME)
     with fs.open(path, "w") as f:
-        f.write("ADDITIONAL_EXTENSIONS_RAW: ext1\n")
-    assert repo_config(path, fs=fs).ADDITIONAL_EXTENSIONS == ["ext1"]
+        f.write("core:\n  ADDITIONAL_EXTENSIONS: ext1\n")
+    assert repo_config(path, fs=fs).additional_extensions == ["ext1"]

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -1,4 +1,8 @@
-from mlem.ext import MLEM_ENTRY_POINT, find_implementations, load_entrypoints
+from mlem.utils.entrypoints import (
+    MLEM_ENTRY_POINT,
+    find_implementations,
+    load_entrypoints,
+)
 
 
 def test_load_entrypoints():


### PR DESCRIPTION
This PR changes MLEM config to be contained in a `core` section. This way the first layer of keys of the config file is all sections and not core config keys + sections for other configs. This also enables MLEM to validate config changes. To do that I also added extension-like entrypoint for config classes so you can validate even external configs