### PR TITLE
readme: fix HTML tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ rf.mlem
 $ cat rf.mlem
 ```
 <details>
-  <summary>> Click to show `cat` output</summary>
+  <summary> Click to show `cat` output</summary>
 
 ```yaml
 artifacts:


### PR DESCRIPTION
It's broken currently:

<img width="557" alt="image" src="https://user-images.githubusercontent.com/1477535/175094660-e0276d48-80fc-4e34-b744-21aa5cdc71e3.png">

> Under https://github.com/iterative/mlem#saving-the-model