### PR TITLE
Mark some tests as flaky

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ line_length = 79
 log_level = debug
 markers =
     long: Marks long-running tests
+    docker: Marks tests that needs Docker
 testpaths =
     tests
 addopts = -rav --durations=0 --cov=mlem --cov-report=term-missing --cov-report=xml

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,8 @@ tests = [
     # we use this to suppress some messages in tests, eg: foo/bar naming,
     # and, protected method calls in our tests
     "pylint-plugin-utils",
+    # we use this to mark tests that needs to be retried
+    "flaky",
     "s3fs",
     "boto3",
     "botocore",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,7 @@ from mlem.runtime.interface import ModelInterface
 RESOURCES = "resources"
 
 long = pytest.mark.long
+flaky = pytest.mark.flaky
 MLEM_TEST_REPO_ORG = "iterative"
 MLEM_TEST_REPO_NAME = "mlem-test"
 MLEM_TEST_REPO = (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from fastapi.testclient import TestClient
+from flaky import flaky  # noqa  # pylint: disable=unused-import
 from fsspec.implementations.local import LocalFileSystem
 from git import GitCommandError, Repo
 from requests import ConnectionError, HTTPError
@@ -33,7 +34,6 @@ from mlem.runtime.interface import ModelInterface
 RESOURCES = "resources"
 
 long = pytest.mark.long
-flaky = pytest.mark.flaky
 MLEM_TEST_REPO_ORG = "iterative"
 MLEM_TEST_REPO_NAME = "mlem-test"
 MLEM_TEST_REPO = (

--- a/tests/contrib/test_heroku.py
+++ b/tests/contrib/test_heroku.py
@@ -153,8 +153,10 @@ def _check_heroku_deployment(meta):
 
 
 def is_not_crash(err, *args):  # pylint: disable=unused-argument
-    time.sleep(10)
-    return not issubclass(err[0], DeploymentError)
+    needs_another_try = issubclass(err[0], DeploymentError)
+    if needs_another_try:
+        time.sleep(10)
+    return not needs_another_try
 
 
 @flaky(rerun_filter=is_not_crash, max_runs=2)

--- a/tests/contrib/test_heroku.py
+++ b/tests/contrib/test_heroku.py
@@ -152,7 +152,12 @@ def _check_heroku_deployment(meta):
     assert len(res) == 1
 
 
-@flaky
+def is_not_crash(err, *args):  # pylint: disable=unused-argument
+    time.sleep(10)
+    return not issubclass(err[0], DeploymentError)
+
+
+@flaky(rerun_filter=is_not_crash, max_runs=2)
 @heroku
 @long
 @heroku_matrix

--- a/tests/contrib/test_heroku.py
+++ b/tests/contrib/test_heroku.py
@@ -28,7 +28,7 @@ from mlem.contrib.heroku.utils import (
 )
 from mlem.core.errors import DeploymentError
 from mlem.core.objects import DeployStatus, MlemModel
-from tests.conftest import long, skip_matrix
+from tests.conftest import flaky, long, skip_matrix
 
 heroku = pytest.mark.skipif(
     HEROKU_CONFIG.API_KEY is None, reason="No HEROKU_API_KEY env provided"
@@ -152,6 +152,7 @@ def _check_heroku_deployment(meta):
     assert len(res) == 1
 
 
+@flaky
 @heroku
 @long
 @heroku_matrix

--- a/tests/core/test_objects.py
+++ b/tests/core/test_objects.py
@@ -24,6 +24,7 @@ from mlem.core.objects import (
 from mlem.core.requirements import InstallableRequirement, Requirements
 from tests.conftest import (
     MLEM_TEST_REPO,
+    flaky,
     long,
     need_test_repo_auth,
     need_test_repo_ssh_auth,
@@ -219,6 +220,7 @@ def test_model_cloning(model_single_path):
         _check_cloned_model(cloned_model_meta, path)
 
 
+@flaky
 def test_complex_model_cloning(complex_model_single_path):
     model = load_meta(complex_model_single_path)
     with tempfile.TemporaryDirectory() as path:


### PR DESCRIPTION
close #326 

See also https://github.com/dropbox/pytest-flakefinder for a way to find those tests

UPD: I've used `pytest-flakefinder` to run all tests 10 times, and only heroku test fails. From what I saw in CI, there are other tests that may fail, so I assume this is due to parallel runs. We can mark more tests as flaky once we find those.