### PR TITLE
Enable `pip install mlem[dvc-s3]` for all relevant DVC dependencies

### DIFF
--- a/.github/workflows/check-test-release.yml
+++ b/.github/workflows/check-test-release.yml
@@ -85,12 +85,11 @@ jobs:
         brew install hdf5 wget c-blosc
         wget https://raw.githubusercontent.com/Homebrew/homebrew-core/fb8323f2b170bd4ae97e1bac9bf3e2983af3fdb0/Formula/libomp.rb
         brew install ./libomp.rb
-    # legacy-resolver makes install faster by order of magnitude
     - name: Install
       if: steps.cache.pip-cache-dir.cache-hit != 'true'
       run: |
         pip install --upgrade pip setuptools wheel
-        pip install pre-commit .[tests] --use-deprecated=legacy-resolver
+        pip install pre-commit .[tests]
     - run: pre-commit run pylint -a -v --show-diff-on-failure
       if: matrix.python != '3.7'
     - name: Run tests

--- a/setup.py
+++ b/setup.py
@@ -79,20 +79,24 @@ extras = {
     "rmq": ["pika"],
     "docker": ["docker"],
     "heroku": ["docker"],
-    # dvc and its dependencies
     "dvc": ["dvc~=2.0"],
-    "dvc-azure": ["dvc[azure]~=2.0"],
-    "dvc-gdrive": ["dvc[gdrive]~=2.0"],
-    "dvc-gs": ["dvc[gs]~=2.0"],
-    "dvc-hdfs": ["dvc[hdfs]~=2.0"],
-    "dvc-oss": ["dvc[oss]~=2.0"],
-    "dvc-s3": ["dvc[s3]~=2.0"],
-    "dvc-ssh": ["dvc[ssh]~=2.0"],
-    "dvc-ssh_gssapi": ["dvc[ssh_gssapi]~=2.0"],
-    "dvc-webdav": ["dvc[webdav]~=2.0"],
-    "dvc-webhdfs": ["dvc[webhdfs]~=2.0"],
-    "dvc-webdhfs_kerberos": ["dvc[webdhfs_kerberos]~=2.0"],
 }
+
+# add DVC extras
+for e in [
+    "azure",
+    "gdrive",
+    "gs",
+    "hdfs",
+    "oss",
+    "s3",
+    "ssh",
+    "ssh_gssapi",
+    "webdav",
+    "webhdfs",
+    "webdhfs_kerberos",
+]:
+    extras[f"dvc-{e}"] = [f"dvc[{e}]~=2.0"]
 
 extras["all"] = [_ for e in extras.values() for _ in e]
 extras["tests"] += [e for e in extras["all"] if not e.startswith("dvc-")]

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ extras = {
 }
 
 extras["all"] = [_ for e in extras.values() for _ in e]
-extras["tests"] += extras["all"]
+extras["tests"] += [e for e in extras["all"] if not e.startswith("dvc-")]
 
 setup_args = dict(  # noqa: C408
     name="mlem",

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ tests = [
 
 extras = {
     "tests": tests,
-    "dvc": ["dvc~=2.0"],
     "pandas": ["pandas"],
     "numpy": ["numpy"],
     "sklearn": ["scikit-learn"],
@@ -80,6 +79,19 @@ extras = {
     "rmq": ["pika"],
     "docker": ["docker"],
     "heroku": ["docker"],
+    # dvc and its dependencies
+    "dvc": ["dvc~=2.0"],
+    "dvc-azure": ["dvc[azure]~=2.0"],
+    "dvc-gdrive": ["dvc[gdrive]~=2.0"],
+    "dvc-gs": ["dvc[gs]~=2.0"],
+    "dvc-hdfs": ["dvc[hdfs]~=2.0"],
+    "dvc-oss": ["dvc[oss]~=2.0"],
+    "dvc-s3": ["dvc[s3]~=2.0"],
+    "dvc-ssh": ["dvc[ssh]~=2.0"],
+    "dvc-ssh_gssapi": ["dvc[ssh_gssapi]~=2.0"],
+    "dvc-webdav": ["dvc[webdav]~=2.0"],
+    "dvc-webhdfs": ["dvc[webhdfs]~=2.0"],
+    "dvc-webdhfs_kerberos": ["dvc[webdhfs_kerberos]~=2.0"],
 }
 
 extras["all"] = [_ for e in extras.values() for _ in e]

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,0 +1,12 @@
+import importlib_metadata
+
+from setup import extras
+
+
+def test_dvc_extras():
+
+    # importlib_metadata checks the locally installed package,
+    # so this may pass locally, but fail in CI
+    for e in importlib_metadata.metadata("dvc").get_all("Provides-Extra"):
+        if e not in {"all", "dev", "terraform", "tests"}:
+            assert extras[f"dvc-{e}"] == [f"dvc[{e}]~=2.0"]

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -7,6 +7,12 @@ def test_dvc_extras():
 
     # importlib_metadata checks the locally installed package,
     # so this may pass locally, but fail in CI
-    for e in importlib_metadata.metadata("dvc").get_all("Provides-Extra"):
-        if e not in {"all", "dev", "terraform", "tests"}:
-            assert extras[f"dvc-{e}"] == [f"dvc[{e}]~=2.0"]
+    correct_extras = {
+        f"dvc-{e}": [f"dvc[{e}]~=2.0"]
+        for e in importlib_metadata.metadata("dvc").get_all("Provides-Extra")
+        if e not in {"all", "dev", "terraform", "tests"}
+    }
+    specified_extras = {
+        e: l for e, l in extras.items() if e[: len("dvc-")] == "dvc-"
+    }
+    assert correct_extras == specified_extras


### PR DESCRIPTION
Added all relevant options from https://github.com/iterative/dvc/blob/main/setup.cfg#L74 (everything except `all`, `terraform`, `tests`).
Basically, extras for all [Storage types supported for remotes](https://dvc.org/doc/command-reference/remote/add#supported-storage-types).

The need for this was found out by @shcheklein [here](https://github.com/iterative/mlem.ai/pull/132#discussion_r919286747).