### PR TITLE
Remove labels and description

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,6 @@ def main():
         rf,
         "rf",
         sample_data=data,
-        labels=["random-forest", "classifier"],
-        description="Random Forest Classifier",
     )
 
 if __name__ == "__main__":
@@ -108,10 +106,6 @@ artifacts:
     hash: ea4f1bf769414fdacc2075ef9de73be5
     size: 163651
     uri: rf
-description: Random Forest Classifier
-labels:
-- random-forest
-- classifier
 model_type:
   methods:
     predict:

--- a/mlem/core/metadata.py
+++ b/mlem/core/metadata.py
@@ -50,7 +50,6 @@ def save(
     index: bool = None,
     external: Optional[bool] = None,
     params: Dict[str, str] = None,
-    update: bool = False,
 ) -> MlemObject:
     """Saves given object to a given path
 
@@ -66,24 +65,10 @@ def save(
         index: Whether to add object to mlem project index
         external: if obj is saved to project, whether to put it outside of .mlem dir
         params: arbitrary params for object
-        update: whether to keep old params if new values were not provided
 
     Returns:
         None
     """
-    if update and params is None:
-        try:
-            old_meta = load_meta(
-                path, project=project, fs=fs, load_value=False
-            )
-            params = params or old_meta.params
-        except MlemObjectNotFound:
-            logger.warning(
-                "Saving with update=True, but no existing object found at %s %s %s",
-                project,
-                path,
-                fs,
-            )
     meta = get_object_metadata(
         obj,
         sample_data,

--- a/mlem/core/metadata.py
+++ b/mlem/core/metadata.py
@@ -4,7 +4,7 @@ searching for MLEM object by given path.
 """
 import logging
 import posixpath
-from typing import Any, Dict, List, Optional, Type, TypeVar, Union, overload
+from typing import Any, Dict, Optional, Type, TypeVar, Union, overload
 
 from fsspec import AbstractFileSystem
 from typing_extensions import Literal
@@ -25,22 +25,19 @@ logger = logging.getLogger(__name__)
 def get_object_metadata(
     obj: Any,
     sample_data=None,
-    description: str = None,
     params: Dict[str, str] = None,
-    labels: List[str] = None,
 ) -> Union[MlemData, MlemModel]:
     """Convert given object to appropriate MlemObject subclass"""
     try:
         return MlemData.from_data(
-            obj, description=description, params=params, labels=labels
+            obj,
+            params=params,
         )
     except HookNotFound:
         return MlemModel.from_obj(
             obj,
             sample_data=sample_data,
-            description=description,
             params=params,
-            labels=labels,
         )
 
 
@@ -52,9 +49,7 @@ def save(
     fs: Union[str, AbstractFileSystem] = None,
     index: bool = None,
     external: Optional[bool] = None,
-    description: str = None,
     params: Dict[str, str] = None,
-    labels: List[str] = None,
     update: bool = False,
 ) -> MlemObject:
     """Saves given object to a given path
@@ -70,22 +65,18 @@ def save(
         fs: FileSystem for the `path` argument
         index: Whether to add object to mlem project index
         external: if obj is saved to project, whether to put it outside of .mlem dir
-        description: description for object
         params: arbitrary params for object
-        labels: labels for object
-        update: whether to keep old description/labels/params if new values were not provided
+        update: whether to keep old params if new values were not provided
 
     Returns:
         None
     """
-    if update and (description is None or params is None or labels is None):
+    if update and params is None:
         try:
             old_meta = load_meta(
                 path, project=project, fs=fs, load_value=False
             )
-            description = description or old_meta.description
             params = params or old_meta.params
-            labels = labels or old_meta.labels
         except MlemObjectNotFound:
             logger.warning(
                 "Saving with update=True, but no existing object found at %s %s %s",
@@ -94,7 +85,9 @@ def save(
                 fs,
             )
     meta = get_object_metadata(
-        obj, sample_data, description=description, params=params, labels=labels
+        obj,
+        sample_data,
+        params=params,
     )
     meta.dump(path, fs=fs, project=project, index=index, external=external)
     return meta

--- a/mlem/core/objects.py
+++ b/mlem/core/objects.py
@@ -15,7 +15,6 @@ from typing import (
     Generic,
     Iterable,
     Iterator,
-    List,
     Optional,
     Tuple,
     Type,
@@ -78,9 +77,7 @@ class MlemObject(MlemABC):
     __abstract__: ClassVar[bool] = True
     object_type: ClassVar[str]
     location: Optional[Location] = None
-    description: Optional[str] = None
     params: Dict[str, str] = {}
-    labels: List[str] = []
 
     @property
     def loc(self) -> Location:
@@ -604,8 +601,6 @@ class MlemModel(_WithArtifacts):
         cls,
         model: Any,
         sample_data: Any = None,
-        description: str = None,
-        labels: List[str] = None,
         params: Dict[str, str] = None,
     ) -> "MlemModel":
         mt = ModelAnalyzer.analyze(model, sample_data=sample_data)
@@ -615,8 +610,6 @@ class MlemModel(_WithArtifacts):
         return MlemModel(
             model_type=mt,
             requirements=mt.get_requirements().expanded,
-            description=description,
-            labels=labels or [],
             params=params or {},
         )
 
@@ -670,18 +663,14 @@ class MlemData(_WithArtifacts):
     def from_data(
         cls,
         data: Any,
-        description: str = None,
         params: Dict[str, str] = None,
-        labels: List[str] = None,
     ) -> "MlemData":
         data_type = DataType.create(
             data,
         )
         meta = MlemData(
             requirements=data_type.get_requirements().expanded,
-            description=description,
             params=params or {},
-            labels=labels or [],
         )
         meta.data_type = data_type
         return meta

--- a/tests/contrib/test_heroku.py
+++ b/tests/contrib/test_heroku.py
@@ -178,7 +178,7 @@ def test_env_deploy_full(
 
     _check_heroku_deployment(meta)
 
-    model.description = "New version"
+    model.params = {"version": "new"}
     model.update()
     redeploy_meta = deploy(meta, model, heroku_env)
 

--- a/tests/core/test_metadata.py
+++ b/tests/core/test_metadata.py
@@ -39,9 +39,8 @@ def test_save_with_meta_fields_update(model, train, tmpdir):
         model,
         path,
         params={"a": "b"},
-        update=True,
     )
-    save(train, path, update=True)
+    save(train, path)
     new = load_meta(path)
     assert new.params == {"a": "b"}
 

--- a/tests/core/test_metadata.py
+++ b/tests/core/test_metadata.py
@@ -33,18 +33,6 @@ def test_save_with_meta_fields(obj, tmpdir):
     assert new.params == {"a": "b"}
 
 
-def test_save_with_meta_fields_update(model, train, tmpdir):
-    path = str(tmpdir / "obj")
-    save(
-        model,
-        path,
-        params={"a": "b"},
-    )
-    save(train, path)
-    new = load_meta(path)
-    assert new.params == {"a": "b"}
-
-
 def test_saving_with_project(model, tmpdir):
     path = str(tmpdir / "obj")
     save(model, path)

--- a/tests/core/test_metadata.py
+++ b/tests/core/test_metadata.py
@@ -28,11 +28,9 @@ from tests.conftest import (
 @pytest.mark.parametrize("obj", [lazy_fixture("model"), lazy_fixture("train")])
 def test_save_with_meta_fields(obj, tmpdir):
     path = str(tmpdir / "obj")
-    save(obj, path, description="desc", params={"a": "b"}, labels=["tag"])
+    save(obj, path, params={"a": "b"})
     new = load_meta(path)
-    assert new.description == "desc"
     assert new.params == {"a": "b"}
-    assert new.labels == ["tag"]
 
 
 def test_save_with_meta_fields_update(model, train, tmpdir):
@@ -40,16 +38,12 @@ def test_save_with_meta_fields_update(model, train, tmpdir):
     save(
         model,
         path,
-        description="desc",
         params={"a": "b"},
-        labels=["tag"],
         update=True,
     )
     save(train, path, update=True)
     new = load_meta(path)
-    assert new.description == "desc"
     assert new.params == {"a": "b"}
-    assert new.labels == ["tag"]
 
 
 def test_saving_with_project(model, tmpdir):

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -6,10 +6,10 @@ from setup import extras
 
 
 def test_dvc_extras():
-
-    # importlib_metadata checks the locally installed package,
-    # so this may pass locally, but fail in CI
-    if version.parse(dvc.__version__) > version.parse("2.11"):
+    # previous to 2.15 DVC had a typo in extras
+    if version.parse(dvc.__version__) > version.parse("2.15"):
+        # importlib_metadata checks the locally installed package,
+        # so this may pass locally, but fail in CI
         correct_extras = {
             f"dvc-{e}": [f"dvc[{e}]~=2.0"]
             for e in importlib_metadata.metadata("dvc").get_all(

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,4 +1,6 @@
+import dvc
 import importlib_metadata
+from packaging import version
 
 from setup import extras
 
@@ -7,12 +9,15 @@ def test_dvc_extras():
 
     # importlib_metadata checks the locally installed package,
     # so this may pass locally, but fail in CI
-    correct_extras = {
-        f"dvc-{e}": [f"dvc[{e}]~=2.0"]
-        for e in importlib_metadata.metadata("dvc").get_all("Provides-Extra")
-        if e not in {"all", "dev", "terraform", "tests"}
-    }
-    specified_extras = {
-        e: l for e, l in extras.items() if e[: len("dvc-")] == "dvc-"
-    }
-    assert correct_extras == specified_extras
+    if version.parse(dvc.__version__) > version.parse("2.11"):
+        correct_extras = {
+            f"dvc-{e}": [f"dvc[{e}]~=2.0"]
+            for e in importlib_metadata.metadata("dvc").get_all(
+                "Provides-Extra"
+            )
+            if e not in {"all", "dev", "terraform", "tests"}
+        }
+        specified_extras = {
+            e: l for e, l in extras.items() if e[: len("dvc-")] == "dvc-"
+        }
+        assert correct_extras == specified_extras


### PR DESCRIPTION
close #368 

I'm keeping `params` for now since I don't think it's contradictory to anything in GTO. Just some meta which users may want to save, so there should be a way to do that. Like "meta" in DVC which doesn't pretend to replace description or labels. WDYT, @mike0sv @dmpetrov 