### PR TITLE
Fix/stderr

### DIFF
--- a/mlem/cli/main.py
+++ b/mlem/cli/main.py
@@ -23,7 +23,15 @@ from mlem.core.errors import MlemError
 from mlem.core.metadata import load_meta
 from mlem.core.objects import MlemObject
 from mlem.telemetry import telemetry
-from mlem.ui import EMOJI_FAIL, EMOJI_MLEM, bold, cli_echo, color, echo
+from mlem.ui import (
+    EMOJI_FAIL,
+    EMOJI_MLEM,
+    bold,
+    cli_echo,
+    color,
+    echo,
+    stderr_echo,
+)
 
 
 class MlemFormatter(HelpFormatter):
@@ -289,7 +297,7 @@ def mlem_command(
                 error = f"{e.__class__.__module__}.{e.__class__.__name__}"
                 if ctx.obj["traceback"]:
                     raise
-                with cli_echo():
+                with stderr_echo():
                     echo(EMOJI_FAIL + color(str(e), col=typer.colors.RED))
                 raise typer.Exit(1)
             except ValidationError as e:
@@ -297,14 +305,14 @@ def mlem_command(
                 if ctx.obj["traceback"]:
                     raise
                 msgs = "\n".join(_format_validation_error(e))
-                with cli_echo():
+                with stderr_echo():
                     echo(EMOJI_FAIL + color("Error:\n", "red") + msgs)
                 raise typer.Exit(1)
             except Exception as e:  # pylint: disable=broad-except
                 error = f"{e.__class__.__module__}.{e.__class__.__name__}"
                 if ctx.obj["traceback"]:
                     raise
-                with cli_echo():
+                with stderr_echo():
                     echo(
                         EMOJI_FAIL
                         + color(

--- a/mlem/ui.py
+++ b/mlem/ui.py
@@ -10,6 +10,7 @@ from rich.text import Text
 from mlem.config import LOCAL_CONFIG
 
 console = Console()
+error_console = Console(stderr=True)
 
 _echo_func: Optional[Callable] = None
 _offset: int = 0
@@ -43,6 +44,12 @@ def set_offset(offset=0):
 @contextlib.contextmanager
 def cli_echo():
     with set_echo(console.print):
+        yield
+
+
+@contextlib.contextmanager
+def stderr_echo():
+    with set_echo(error_console.print):
         yield
 
 

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,6 @@ for e in [
     "s3",
     "ssh",
     "ssh_gssapi",
-    "testing",
     "webdav",
     "webhdfs",
     "webhdfs_kerberos",

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ tests = [
     "pyarrow",
     "skl2onnx",
     "dvc[s3]",
+    "importlib_metadata",
 ]
 
 extras = {
@@ -93,6 +94,7 @@ for e in [
     "s3",
     "ssh",
     "ssh_gssapi",
+    "testing",
     "webdav",
     "webhdfs",
     "webhdfs_kerberos",

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -7,7 +7,7 @@ from mlem.cli import app
 
 class Runner:
     def __init__(self):
-        self._runner = CliRunner()
+        self._runner = CliRunner(mix_stderr=False)
 
     def invoke(self, *args, **kwargs) -> Result:
         return self._runner.invoke(app, *args, **kwargs)

--- a/tests/cli/test_apply.py
+++ b/tests/cli/test_apply.py
@@ -38,7 +38,11 @@ def test_apply(runner, model_path, data_path):
                 "--no-index",
             ],
         )
-        assert result.exit_code == 0, (result.output, result.exception)
+        assert result.exit_code == 0, (
+            result.stdout,
+            result.stderr,
+            result.exception,
+        )
         predictions = load(path)
         assert isinstance(predictions, ndarray)
 
@@ -85,7 +89,11 @@ def test_apply_batch(runner, model_path_batch, data_path_batch):
                 "5",
             ],
         )
-        assert result.exit_code == 0, (result.output, result.exception)
+        assert result.exit_code == 0, (
+            result.stdout,
+            result.stderr,
+            result.exception,
+        )
         predictions_meta = load_meta(
             path, load_value=True, force_type=MlemData
         )
@@ -116,7 +124,11 @@ def test_apply_with_import(runner, model_meta_saved_single, tmp_path_factory):
                 "pandas[csv]",
             ],
         )
-        assert result.exit_code == 0, (result.output, result.exception)
+        assert result.exit_code == 0, (
+            result.stdout,
+            result.stderr,
+            result.exception,
+        )
         predictions = load(path)
         assert isinstance(predictions, ndarray)
 
@@ -146,10 +158,14 @@ def test_apply_batch_with_import(
                 "2",
             ],
         )
-        assert result.exit_code == 1, (result.output, result.exception)
+        assert result.exit_code == 1, (
+            result.stdout,
+            result.stderr,
+            result.exception,
+        )
         assert (
             "Batch data loading is currently not supported for loading data on-the-fly"
-            in result.output
+            in result.stderr
         )
 
 
@@ -157,8 +173,12 @@ def test_apply_no_output(runner, model_path, data_path):
     result = runner.invoke(
         ["apply", model_path, data_path, "-m", "predict", "--no-index"],
     )
-    assert result.exit_code == 0, (result.output, result.exception)
-    assert len(result.output) > 0
+    assert result.exit_code == 0, (
+        result.stdout,
+        result.stderr,
+        result.exception,
+    )
+    assert len(result.stdout) > 0
 
 
 def test_apply_fails_without_mlem_dir(runner, model_path, data_path):
@@ -176,7 +196,11 @@ def test_apply_fails_without_mlem_dir(runner, model_path, data_path):
                 "--index",
             ],
         )
-        assert result.exit_code == 1, (result.output, result.exception)
+        assert result.exit_code == 1, (
+            result.stdout,
+            result.stderr,
+            result.exception,
+        )
         assert isinstance(result.exception, MlemProjectNotFound)
 
 
@@ -206,7 +230,11 @@ def test_apply_from_remote(runner, current_test_branch, s3_tmp_path):
             "--no-index",
         ],
     )
-    assert result.exit_code == 0, (result.output, result.exception)
+    assert result.exit_code == 0, (
+        result.stdout,
+        result.stderr,
+        result.exception,
+    )
     predictions = load(out)
     assert isinstance(predictions, ndarray)
 
@@ -227,6 +255,10 @@ def test_apply_remote(mlem_client, runner, data_path):
                 path,
             ],
         )
-        assert result.exit_code == 0, (result.output, result.exception)
+        assert result.exit_code == 0, (
+            result.stdout,
+            result.stderr,
+            result.exception,
+        )
         predictions = load(path)
         assert isinstance(predictions, ndarray)

--- a/tests/cli/test_build.py
+++ b/tests/cli/test_build.py
@@ -21,7 +21,11 @@ def test_build(runner: Runner, model_meta_saved_single, tmp_path):
         f"build {make_posix(model_meta_saved_single.loc.uri)} -c target={make_posix(path)} mock"
     )
 
-    assert result.exit_code == 0, (result.exception, result.output)
+    assert result.exit_code == 0, (
+        result.stdout,
+        result.stderr,
+        result.exception,
+    )
 
     with open(path, encoding="utf8") as f:
         assert f.read().strip() == model_meta_saved_single.loc.path

--- a/tests/cli/test_checkenv.py
+++ b/tests/cli/test_checkenv.py
@@ -7,7 +7,11 @@ def test_checkenv(runner, model_path_mlem_project):
     result = runner.invoke(
         ["checkenv", model_path],
     )
-    assert result.exit_code == 0, (result.output, result.exception)
+    assert result.exit_code == 0, (
+        result.stdout,
+        result.stderr,
+        result.exception,
+    )
 
     meta = load_meta(model_path, load_value=False, force_type=MlemModel)
     meta.requirements.__root__[0].version = "asdad"
@@ -16,4 +20,8 @@ def test_checkenv(runner, model_path_mlem_project):
     result = runner.invoke(
         ["checkenv", model_path],
     )
-    assert result.exit_code == 1, (result.output, result.exception)
+    assert result.exit_code == 1, (
+        result.stdout,
+        result.stderr,
+        result.exception,
+    )

--- a/tests/cli/test_clone.py
+++ b/tests/cli/test_clone.py
@@ -9,5 +9,9 @@ def test_model_cloning(runner: Runner, model_path):
     with tempfile.TemporaryDirectory() as path:
         path = posixpath.join(path, "cloned")
         result = runner.invoke(["clone", model_path, path, "--no-index"])
-        assert result.exit_code == 0, (result.exception, result.output)
+        assert result.exit_code == 0, (
+            result.stdout,
+            result.stderr,
+            result.exception,
+        )
         load_meta(path, load_value=False)

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -50,7 +50,7 @@ def test_set_get_validation(runner: Runner, mlem_project):
     assert result.exit_code == 1
     assert (
         isinstance(result.exception, ValidationError)
-        or "extra fields not permitted" in result.output
+        or "extra fields not permitted" in result.stderr
     ), traceback.format_exception(
         type(result.exception),
         result.exception,
@@ -64,7 +64,7 @@ def test_set_get_validation(runner: Runner, mlem_project):
     assert result.exit_code == 1
     assert (
         isinstance(result.exception, MlemError)
-        or "[name] should contain at least one dot" in result.output
+        or "[name] should contain at least one dot" in result.stderr
     ), traceback.format_exception(
         type(result.exception),
         result.exception,

--- a/tests/cli/test_deployment.py
+++ b/tests/cli/test_deployment.py
@@ -84,7 +84,11 @@ def test_deploy_create_new(
     result = runner.invoke(
         f"deploy run {path} -m {model_meta_saved_single.loc.uri} -t {mock_env_path} -c param=aaa".split()
     )
-    assert result.exit_code == 0, result.output
+    assert result.exit_code == 0, (
+        result.stdout,
+        result.stderr,
+        result.exception,
+    )
     assert os.path.isfile(path + MLEM_EXT)
     meta = load_meta(path)
     assert isinstance(meta, MlemDeploymentMock)
@@ -94,7 +98,11 @@ def test_deploy_create_new(
 
 def test_deploy_create_existing(runner: Runner, mock_deploy_path):
     result = runner.invoke(f"deploy run {mock_deploy_path}".split())
-    assert result.exit_code == 0, result.output
+    assert result.exit_code == 0, (
+        result.stdout,
+        result.stderr,
+        result.exception,
+    )
     meta = load_meta(mock_deploy_path)
     assert isinstance(meta, MlemDeploymentMock)
     assert meta.param == "bbb"
@@ -103,13 +111,21 @@ def test_deploy_create_existing(runner: Runner, mock_deploy_path):
 
 def test_deploy_status(runner: Runner, mock_deploy_path):
     result = runner.invoke(f"deploy status {mock_deploy_path}".split())
-    assert result.exit_code == 0, result.output
-    assert result.output.strip() == DeployStatus.NOT_DEPLOYED.value
+    assert result.exit_code == 0, (
+        result.stdout,
+        result.stderr,
+        result.exception,
+    )
+    assert result.stdout.strip() == DeployStatus.NOT_DEPLOYED.value
 
 
 def test_deploy_remove(runner: Runner, mock_deploy_path):
     result = runner.invoke(f"deploy remove {mock_deploy_path}".split())
-    assert result.exit_code == 0, result.output
+    assert result.exit_code == 0, (
+        result.stdout,
+        result.stderr,
+        result.exception,
+    )
     meta = load_meta(mock_deploy_path)
     assert isinstance(meta, MlemDeploymentMock)
     assert meta.status == DeployStatus.STOPPED
@@ -126,7 +142,11 @@ def test_deploy_apply(
     result = runner.invoke(
         f"deploy apply {mock_deploy_path} {data_path} -o {path}".split()
     )
-    assert result.exit_code == 0, result.output
+    assert result.exit_code == 0, (
+        result.stdout,
+        result.stderr,
+        result.exception,
+    )
     meta = load_meta(mock_deploy_path)
     assert isinstance(meta, MlemDeploymentMock)
     assert meta.status == DeployStatus.NOT_DEPLOYED

--- a/tests/cli/test_import_path.py
+++ b/tests/cli/test_import_path.py
@@ -26,7 +26,11 @@ def test_import_model_pickle_copy(
     result = runner.invoke(
         ["import", path, out_path, "--type", type_, "--copy"],
     )
-    assert result.exit_code == 0, (result.output, result.exception)
+    assert result.exit_code == 0, (
+        result.stdout,
+        result.stderr,
+        result.exception,
+    )
 
     loaded = load(out_path)
     loaded.predict(train)

--- a/tests/cli/test_info.py
+++ b/tests/cli/test_info.py
@@ -20,16 +20,24 @@ def test_ls(runner, filled_mlem_project, obj_type):
     result = runner.invoke(
         ["list", "-t", obj_type] if obj_type else ["list"],
     )
-    assert result.exit_code == 0, (result.output, result.exception)
-    assert len(result.output) > 0, "Output is empty, but should not be"
-    assert result.output == LOCAL_LS_EXPECTED_RESULT
+    assert result.exit_code == 0, (
+        result.stdout,
+        result.stderr,
+        result.exception,
+    )
+    assert len(result.stdout) > 0, "Output is empty, but should not be"
+    assert result.stdout == LOCAL_LS_EXPECTED_RESULT
 
     result = runner.invoke(
         (["list", "-t", obj_type] if obj_type else ["list"]) + ["--json"],
     )
-    assert result.exit_code == 0, (result.output, result.exception)
-    assert len(result.output) > 0, "Output is empty, but should not be"
-    data = json.loads(result.output)
+    assert result.exit_code == 0, (
+        result.stdout,
+        result.stderr,
+        result.exception,
+    )
+    assert len(result.stdout) > 0, "Output is empty, but should not be"
+    data = json.loads(result.stdout)
     assert "model" in data
     models = data["model"]
     assert len(models) == 2
@@ -59,9 +67,13 @@ def test_ls_remote(runner, current_test_branch):
             f"{MLEM_TEST_REPO}/tree/{current_test_branch}/simple",
         ],
     )
-    assert result.exit_code == 0, (result.output, result.exception)
-    assert len(result.output) > 0, "Output is empty, but should not be"
-    assert result.output == REMOTE_LS_EXPECTED_RESULT
+    assert result.exit_code == 0, (
+        result.stdout,
+        result.stderr,
+        result.exception,
+    )
+    assert len(result.stdout) > 0, "Output is empty, but should not be"
+    assert result.stdout == REMOTE_LS_EXPECTED_RESULT
 
 
 def test_pretty_print(runner, model_path_mlem_project):
@@ -69,13 +81,21 @@ def test_pretty_print(runner, model_path_mlem_project):
     result = runner.invoke(
         ["pprint", model_path + MLEM_EXT],
     )
-    assert result.exit_code == 0, (result.output, result.exception)
+    assert result.exit_code == 0, (
+        result.stdout,
+        result.stderr,
+        result.exception,
+    )
 
     result = runner.invoke(
         ["pprint", model_path + MLEM_EXT, "--json"],
     )
-    assert result.exit_code == 0, (result.output, result.exception)
-    meta = parse_obj_as(MlemObject, json.loads(result.output))
+    assert result.exit_code == 0, (
+        result.stdout,
+        result.stderr,
+        result.exception,
+    )
+    meta = parse_obj_as(MlemObject, json.loads(result.stdout))
     assert isinstance(meta, MlemModel)
 
 
@@ -87,4 +107,8 @@ def test_pretty_print_remote(runner, current_test_branch):
     result = runner.invoke(
         ["pprint", model_path + MLEM_EXT],
     )
-    assert result.exit_code == 0, (result.output, result.exception)
+    assert result.exit_code == 0, (
+        result.stdout,
+        result.stderr,
+        result.exception,
+    )

--- a/tests/cli/test_link.py
+++ b/tests/cli/test_link.py
@@ -12,7 +12,11 @@ def test_link(runner, model_path):
         result = runner.invoke(
             ["link", model_path, link_path, "-e", "--abs"],
         )
-        assert result.exit_code == 0, (result.output, result.exception)
+        assert result.exit_code == 0, (
+            result.stdout,
+            result.stderr,
+            result.exception,
+        )
         assert os.path.exists(link_path)
         model = load_meta(link_path)
         assert isinstance(model, MlemModel)
@@ -24,7 +28,11 @@ def test_link_mlem_project(runner, model_path_mlem_project):
     result = runner.invoke(
         ["link", model_path, link_name, "--target-project", project],
     )
-    assert result.exit_code == 0, result.output
+    assert result.exit_code == 0, (
+        result.stdout,
+        result.stderr,
+        result.exception,
+    )
     link_path = os.path.join(
         project, MLEM_DIR, MlemLink.object_type, link_name
     )

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -65,18 +65,30 @@ def test_commands_examples(app_cli_cmd):
 @pytest.mark.parametrize("cmd", ["--help", "-h"])
 def test_help(runner: Runner, cmd):
     result = runner.invoke(cmd)
-    assert result.exit_code == 0, (result.exception, result.output)
+    assert result.exit_code == 0, (
+        result.stdout,
+        result.stderr,
+        result.exception,
+    )
 
 
 def test_cli_commands_help(runner: Runner, app_cli_cmd):
     for name, _ in app_cli_cmd:
         result = runner.invoke(name + " --help")
-        assert result.exit_code == 0, (name, result.exception, result.output)
+        assert result.exit_code == 0, (
+            result.stdout,
+            result.stderr,
+            result.exception,
+        )
 
 
 def test_version(runner: Runner):
     from mlem import __version__
 
     result = runner.invoke("--version")
-    assert result.exit_code == 0, (result.exception, result.output)
-    assert __version__ in result.output
+    assert result.exit_code == 0, (
+        result.stdout,
+        result.stderr,
+        result.exception,
+    )
+    assert __version__ in result.stdout

--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -16,5 +16,9 @@ class MockServer(Server):
 
 def test_serve(runner: Runner, model_single_path):
     result = runner.invoke(f"serve {model_single_path} mock -c param=aaa")
-    assert result.exit_code == 0, result.exception
-    assert result.output.splitlines()[-1] == "aaa"
+    assert result.exit_code == 0, (
+        result.stdout,
+        result.stderr,
+        result.exception,
+    )
+    assert result.stdout.splitlines()[-1] == "aaa"

--- a/tests/cli/test_stderr.py
+++ b/tests/cli/test_stderr.py
@@ -1,0 +1,42 @@
+from unittest import mock
+
+from mlem.core.errors import MlemError
+
+EXCEPTION_MESSAGE = "Test Exception Message"
+
+
+def test_stderr_exception(runner):
+    # patch the ls command and ensure it throws an expection.
+    with mock.patch(
+        "mlem.api.commands.ls", side_effect=Exception(EXCEPTION_MESSAGE)
+    ):
+        result = runner.invoke(
+            ["list"],
+        )
+        assert result.exit_code == 1, (
+            result.stdout,
+            result.stderr,
+            result.exception,
+        )
+        assert len(result.stderr) > 0, "Output is empty, but should not be"
+        assert EXCEPTION_MESSAGE in result.stderr
+
+
+MLEM_ERROR_MESSAGE = "Test Mlem Error Message"
+
+
+def test_stderr_mlem_error(runner):
+    # patch the ls command and ensure it thrown a mlem error.
+    with mock.patch(
+        "mlem.api.commands.ls", side_effect=MlemError(MLEM_ERROR_MESSAGE)
+    ):
+        result = runner.invoke(
+            ["list"],
+        )
+        assert result.exit_code == 1, (
+            result.stdout,
+            result.stderr,
+            result.exception,
+        )
+        assert len(result.stderr) > 0, "Output is empty, but should not be"
+        assert MLEM_ERROR_MESSAGE in result.stderr

--- a/tests/cli/test_stderr.py
+++ b/tests/cli/test_stderr.py
@@ -26,7 +26,7 @@ MLEM_ERROR_MESSAGE = "Test Mlem Error Message"
 
 
 def test_stderr_mlem_error(runner):
-    # patch the ls command and ensure it thrown a mlem error.
+    # patch the ls command and ensure it throws a mlem error.
     with mock.patch(
         "mlem.api.commands.ls", side_effect=MlemError(MLEM_ERROR_MESSAGE)
     ):

--- a/tests/cli/test_stderr.py
+++ b/tests/cli/test_stderr.py
@@ -1,6 +1,8 @@
+from io import StringIO
 from unittest import mock
 
 from mlem.core.errors import MlemError
+from mlem.ui import echo, stderr_echo
 
 EXCEPTION_MESSAGE = "Test Exception Message"
 
@@ -40,3 +42,16 @@ def test_stderr_mlem_error(runner):
         )
         assert len(result.stderr) > 0, "Output is empty, but should not be"
         assert MLEM_ERROR_MESSAGE in result.stderr
+
+
+STDERR_MESSAGE = "Test Stderr Message"
+
+
+def test_stderr_echo():
+    with mock.patch("sys.stderr", new_callable=StringIO) as mock_stderr:
+        with stderr_echo():
+            echo(STDERR_MESSAGE)
+            mock_stderr.seek(0)
+            output = mock_stderr.read()
+            assert len(output) > 0, "Output is empty, but should not be"
+            assert STDERR_MESSAGE in output

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -15,7 +15,7 @@ def test_dvc_extras():
             for e in importlib_metadata.metadata("dvc").get_all(
                 "Provides-Extra"
             )
-            if e not in {"all", "dev", "terraform", "tests"}
+            if e not in {"all", "dev", "terraform", "testing", "tests"}
         }
         specified_extras = {
             e: l for e, l in extras.items() if e[: len("dvc-")] == "dvc-"


### PR DESCRIPTION
Decided Approach: 

I noticed that exceptions thrown and eventually caught in `mlem/cli/main.py` utilize the `cli_echo` context manager and the `echo` function to print exceptions to the console. 

The `cli_echo` context manager sets the `echo` function to print to `stdout` through a `Console` instance provided by the Rich package. By default, `Console` will write to `stdout`, hence the reason why exceptions are printed to `stdout`. 

I did some research and discovered that the Rich package supports consoles that can print to `stderr` by passing `stderr=True` when creating the `Console`. With this knowledge, I created a `Console` instance called `error_console` with `stderr=True`. If an error needs to be printed to `stderr`, we can utilize the `error_console` and if we need to print to `stdout`, the existing `console` which prints to `stdout` can be used. 

I then introduced a new context manager called `stderr_echo` that will switch the `echo` function’s underlying print function to `error_console.print` when an error needs to be printed. If printing to `stdout` is required, then we will utilize the exisitng `cli_echo` context manager that will switch the `echo` function’s underlying print function to `console.print`.


With this approach, we use the existing Rich package for printing to both `stdout` and `stderr` thus providing consistency. Additionally, it allows us to keep the signature of the `echo` function the same and let Rich manage printing to different streams under the hood. 



Alternative Approaches: 

I thought about other approaches to implement printing to `stderr`, for example, using `sys.stderr.write` directly. The problem with this approach is that the `echo` function currently excepts multiple parameters including a `Text` instance (along with other configurations) specific to the Rich package, however `sys.stderr.write` requires only a string parameter. 

If we were to use this approach, we’d need to write code to only accept a string parameter (but not a `Text` instance) if we’re printing an error. It is possible through function overloading, however, it’s definitely a cleaner implementation to handling this through the Rich package. 


Related Tasks: 

If this approach is accepted and merged, I will update the contribution guide to explain the usage of the `cli_echo` and `stderr_echo` context managers along with the `echo` function. 


Testing: 

With the ability to print to both `stdout` and `stderr`, it is important that we are able to develop tests that are capable of reading and differentiating outputs from both these streams. 

In the current cli test module, the `CliRunner` instance writes both `stdout` and `stderr` streams to `result.output`. If a test needs to differentiate where the output came from, it is unable to do so. 

I’ve performed a couple updates to the cli test module. 

1.	I’ve updated the `CliRunner` instance by using `mix_stderr=False`, which outputs the `stderr` stream to `result.stderr` and outputs the `stdout` stream to `result.stdout`.  
2.	I’ve updated all tests in the cli test module to use `result.stderr` and/or `result.stdout` for their `assert` statements.
3.	I’ve update cli tests so that error messages for `assert` statements will now print the `stdout` stream, `stderr` stream and exceptions by using `(result.stdout, result.stderr, result.exception)`. 
4.	I’ve implemented tests to ensure that `MlemError` and `Exception` are printed to stderr. 


close https://github.com/iterative/mlem/issues/404