### PR TITLE
Fix/verbose mode

### DIFF
--- a/tests/cli/test_apply.py
+++ b/tests/cli/test_apply.py
@@ -10,7 +10,6 @@ from sklearn.tree import DecisionTreeClassifier
 
 from mlem.api import load, save
 from mlem.core.data_type import ArrayType
-from mlem.core.errors import MlemProjectNotFound
 from mlem.core.metadata import load_meta
 from mlem.core.objects import MlemData
 from mlem.runtime.client import HTTPClient
@@ -196,12 +195,13 @@ def test_apply_fails_without_mlem_dir(runner, model_path, data_path):
                 "--index",
             ],
         )
+        print(result.stderr)
         assert result.exit_code == 1, (
             result.stdout,
             result.stderr,
             result.exception,
         )
-        assert isinstance(result.exception, MlemProjectNotFound)
+        assert "MlemProjectNotFound" in result.stderr
 
 
 @long

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -1,10 +1,5 @@
-import traceback
-
-from pydantic import ValidationError
-
 from mlem.config import project_config
 from mlem.contrib.pandas import PandasConfig
-from mlem.core.errors import MlemError
 from tests.cli.conftest import Runner
 
 
@@ -48,13 +43,10 @@ def test_set_get_validation(runner: Runner, mlem_project):
     )
 
     assert result.exit_code == 1
-    assert (
-        isinstance(result.exception, ValidationError)
-        or "extra fields not permitted" in result.stderr
-    ), traceback.format_exception(
-        type(result.exception),
+    assert "extra fields not permitted" in result.stderr, (
+        result.stdout,
+        result.stderr,
         result.exception,
-        result.exception.__traceback__,
     )
 
     result = runner.invoke(
@@ -62,13 +54,10 @@ def test_set_get_validation(runner: Runner, mlem_project):
     )
 
     assert result.exit_code == 1
-    assert (
-        isinstance(result.exception, MlemError)
-        or "[name] should contain at least one dot" in result.stderr
-    ), traceback.format_exception(
-        type(result.exception),
+    assert "should contain at least one dot" in result.stderr, (
+        result.stdout,
+        result.stderr,
         result.exception,
-        result.exception.__traceback__,
     )
 
     result = runner.invoke(

--- a/tests/cli/test_stderr.py
+++ b/tests/cli/test_stderr.py
@@ -5,6 +5,9 @@ from mlem.core.errors import MlemError
 from mlem.ui import echo, stderr_echo
 
 EXCEPTION_MESSAGE = "Test Exception Message"
+MLEM_ERROR_MESSAGE = "Test Mlem Error Message"
+STDERR_MESSAGE = "Test Stderr Message"
+TRACEBACK_IDENTIFIER_MESSAGE = "raise effect"
 
 
 def test_stderr_exception(runner):
@@ -24,9 +27,6 @@ def test_stderr_exception(runner):
         assert EXCEPTION_MESSAGE in result.stderr
 
 
-MLEM_ERROR_MESSAGE = "Test Mlem Error Message"
-
-
 def test_stderr_mlem_error(runner):
     # patch the ls command and ensure it throws a mlem error.
     with mock.patch(
@@ -44,9 +44,6 @@ def test_stderr_mlem_error(runner):
         assert MLEM_ERROR_MESSAGE in result.stderr
 
 
-STDERR_MESSAGE = "Test Stderr Message"
-
-
 def test_stderr_echo():
     with mock.patch("sys.stderr", new_callable=StringIO) as mock_stderr:
         with stderr_echo():
@@ -55,3 +52,79 @@ def test_stderr_echo():
             output = mock_stderr.read()
             assert len(output) > 0, "Output is empty, but should not be"
             assert STDERR_MESSAGE in output
+
+
+def test_traceback_option_exception(runner):
+    # patch the ls command and ensure it throws an expection.
+    with mock.patch(
+        "mlem.api.commands.ls", side_effect=Exception(EXCEPTION_MESSAGE)
+    ):
+        result = runner.invoke(
+            ["--tb", "list"],
+        )
+        assert result.exit_code == 1, (
+            result.stdout,
+            result.stderr,
+            result.exception,
+        )
+
+        assert len(result.stderr) > 0, "Output is empty, but should not be"
+        assert TRACEBACK_IDENTIFIER_MESSAGE in result.stderr
+        assert EXCEPTION_MESSAGE in result.stderr
+
+
+def test_traceback_option_mlem_error(runner):
+    # patch the ls command and ensure it throws an expection.
+    with mock.patch(
+        "mlem.api.commands.ls", side_effect=MlemError(MLEM_ERROR_MESSAGE)
+    ):
+        result = runner.invoke(
+            ["--tb", "list"],
+        )
+        assert result.exit_code == 1, (
+            result.stdout,
+            result.stderr,
+            result.exception,
+        )
+
+        assert len(result.stderr) > 0, "Output is empty, but should not be"
+        assert TRACEBACK_IDENTIFIER_MESSAGE in result.stderr
+        assert MLEM_ERROR_MESSAGE in result.stderr
+
+
+def test_verbose_option_exception(runner):
+    # patch the ls command and ensure it throws an expection.
+    with mock.patch(
+        "mlem.api.commands.ls", side_effect=Exception(EXCEPTION_MESSAGE)
+    ):
+        result = runner.invoke(
+            ["--verbose", "list"],
+        )
+        assert result.exit_code == 1, (
+            result.stdout,
+            result.stderr,
+            result.exception,
+        )
+
+        assert len(result.stderr) > 0, "Output is empty, but should not be"
+        assert TRACEBACK_IDENTIFIER_MESSAGE in result.stderr
+        assert EXCEPTION_MESSAGE in result.stderr
+
+
+def test_verbose_option_mlem_error(runner):
+    # patch the ls command and ensure it throws an expection.
+    with mock.patch(
+        "mlem.api.commands.ls", side_effect=MlemError(MLEM_ERROR_MESSAGE)
+    ):
+        result = runner.invoke(
+            ["--verbose", "list"],
+        )
+        assert result.exit_code == 1, (
+            result.stdout,
+            result.stderr,
+            result.exception,
+        )
+
+        assert len(result.stderr) > 0, "Output is empty, but should not be"
+        assert TRACEBACK_IDENTIFIER_MESSAGE in result.stderr
+        assert MLEM_ERROR_MESSAGE in result.stderr


### PR DESCRIPTION
Decided Approach: 

Typer implements a callback that allows users to provide parameters for the main cli application, including printing the application version, printing a traceback and printing logs through verbose mode. 

In reviewing the implementation for printing a traceback, it uses the `traceback` property on the context object to track if the user enabled traceback printing. The `traceback` property on the context object is enabled by the either explicitly setting the `--trackback` option or setting the `DEBUG` property of `LOCAL_CONFIG` to true. I’ve included the relevant source code below: 

`ctx.obj = {"traceback": traceback or LOCAL_CONFIG.DEBUG}`

We can easily print a traceback through the `--verbose` option by checking if the verbose option was provided in the cli and changing the state of the `traceback` property accordingly (shown below).

`ctx.obj = {"traceback": traceback or verbose or LOCAL_CONFIG.DEBUG}`

User Experience / Messaging Updates

I’ve also implemented the suggestion by @mike0sv to include a message to use the `--tb` or `--traceback` option in the case of unexpected errors. I’ve included the error message below: 

`Use the --tb or --traceback option to include the traceback in the output`

I've also added a similar message and workflow for `MlemError` and `ValidationError` since they raise exceptions as well. 


I also added tests for `--traceback` and `--verbose` options to ensure that exception data is sent to stderr when exceptions are thrown. These tests are located in `tests/cli/test_stderr.py` since we're checking the contents of stderr. 

I also needed to make a couple modifications to a few existing tests since they checked for raised exceptions, instead, I've modified them to look for `raise [Exception Type]` in stderr. 


Things I'm Unsure About

After I updated  `ctx.obj = {"traceback": traceback or verbose or LOCAL_CONFIG.DEBUG}` to check the value of `verbose` the `tests/contrib/test_onnx.py::test_model_type__dump_load` fails. I can't put by finger on why this is occurring. 


