### PR TITLE
Remove `xfail` mark from `tests/cli/test_main.py::test_commands_docs_links`

### DIFF
--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -61,7 +61,6 @@ def test_commands_args_help(app_cli_cmd):
     assert len(no_help) == 0, f"{no_help} cli commands args do not have help!"
 
 
-@pytest.mark.xfail
 @long
 def test_commands_docs_links(app_cli_cmd):
     no_link = []

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -62,13 +62,13 @@ def test_commands_args_help(app_cli_cmd):
 
 
 @long
-def test_commands_docs_links(app_cli_cmd):
+def test_commands_docs_links(runner: Runner, app_cli_cmd):
     no_link = []
     link_broken = []
     for name, _cmd in app_cli_cmd:
-        result = Runner().invoke(name.split() + ["--help"])
+        result = runner.invoke(name.split() + ["--help"])
         if result.output is None or "Documentation: <" not in result.output:
-            no_link.append(name)
+            no_link.append((name, result.output))
         else:
             link = result.output.split("Documentation: <")[1].split(">")[0]
             response = requests.get(link, timeout=5)

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -54,7 +54,9 @@ def test_commands_help(app_cli_cmd):
             else:
                 link = cli_cmd.help.split("Documentation: <")[1].split(">")[0]
                 response = requests.head(link, timeout=5)
-                if response.status_code != 200:
+                try:
+                    response.raise_for_status()
+                except requests.HTTPError:
                     link_broken.append(name)
 
     assert len(no_help) == 0, f"{no_help} cli commands do not have help!"


### PR DESCRIPTION
Can do now since docs are released.