### PR TITLE
Verbose logging on object loads

### DIFF
--- a/mlem/contrib/pandas.py
+++ b/mlem/contrib/pandas.py
@@ -4,8 +4,8 @@ Extension type: data
 DataType, Reader and Writer implementations for `pd.DataFrame` and `pd.Series`
 ImportHook implementation for files saved with pandas
 """
-import os.path
 import logging
+import os.path
 import posixpath
 import re
 from abc import ABC
@@ -693,7 +693,6 @@ class PandasImport(ExtImportHook, LoadAndAnalyzeImportHook):
 
     @classmethod
     def load_obj(cls, location: Location, modifier: Optional[str], **kwargs):
-
         class _LazyDescribe:
             def __init__(self, _df):
                 self._df = _df
@@ -709,5 +708,8 @@ class PandasImport(ExtImportHook, LoadAndAnalyzeImportHook):
             df = fmt.read_func(f, **read_args)
 
             # note: should consider using head() here, more meaningful for small dfs and vectors
-            logger.debug("Loaded dataframe object, showing 'describe'\n %s", _LazyDescribe(df))
+            logger.debug(
+                "Loaded dataframe object, showing 'describe'\n %s",
+                _LazyDescribe(df),
+            )
             return df

--- a/mlem/contrib/pandas.py
+++ b/mlem/contrib/pandas.py
@@ -5,6 +5,7 @@ DataType, Reader and Writer implementations for `pd.DataFrame` and `pd.Series`
 ImportHook implementation for files saved with pandas
 """
 import os.path
+import logging
 import posixpath
 import re
 from abc import ABC
@@ -67,6 +68,9 @@ _PD_EXT_TYPES = {
 PD_EXT_TYPES = {
     dtype: re.compile(pattern) for dtype, pattern in _PD_EXT_TYPES.items()
 }
+
+
+logger = logging.getLogger(__name__)
 
 
 def string_repr_from_pd_type(
@@ -694,4 +698,8 @@ class PandasImport(ExtImportHook, LoadAndAnalyzeImportHook):
         read_args = fmt.read_args or {}
         read_args.update(kwargs)
         with location.open("rb") as f:
-            return fmt.read_func(f, **read_args)
+            df = fmt.read_func(f, **read_args)
+
+            # note: should consider using head() here, more meaningful for small dfs and vectors
+            logger.debug("Loaded dataframe object, showing 'describe'\n %s", df.head())
+            return df

--- a/mlem/contrib/pandas.py
+++ b/mlem/contrib/pandas.py
@@ -693,6 +693,14 @@ class PandasImport(ExtImportHook, LoadAndAnalyzeImportHook):
 
     @classmethod
     def load_obj(cls, location: Location, modifier: Optional[str], **kwargs):
+
+        class _LazyDescribe:
+            def __init__(self, _df):
+                self._df = _df
+
+            def __str__(self):
+                return str(self._df.describe())
+
         ext = modifier or posixpath.splitext(location.path)[1][1:]
         fmt = PANDAS_FORMATS[ext]
         read_args = fmt.read_args or {}
@@ -701,5 +709,5 @@ class PandasImport(ExtImportHook, LoadAndAnalyzeImportHook):
             df = fmt.read_func(f, **read_args)
 
             # note: should consider using head() here, more meaningful for small dfs and vectors
-            logger.debug("Loaded dataframe object, showing 'describe'\n %s", df.head())
+            logger.debug("Loaded dataframe object, showing 'describe'\n %s", _LazyDescribe(df))
             return df

--- a/mlem/contrib/torch.py
+++ b/mlem/contrib/torch.py
@@ -5,10 +5,10 @@ ModelType and ModelIO implementations for `torch.nn.Module`
 ImportHook for importing files saved with `torch.save`
 DataType, Reader and Writer implementations for `torch.Tensor`
 """
+import logging
 from typing import Any, ClassVar, Iterator, List, Optional, Tuple
 
 import cloudpickle
-import logging
 import torch
 from pydantic import conlist, create_model
 

--- a/mlem/contrib/torch.py
+++ b/mlem/contrib/torch.py
@@ -8,6 +8,7 @@ DataType, Reader and Writer implementations for `torch.Tensor`
 from typing import Any, ClassVar, Iterator, List, Optional, Tuple
 
 import cloudpickle
+import logging
 import torch
 from pydantic import conlist, create_model
 
@@ -33,6 +34,9 @@ from mlem.core.requirements import InstallableRequirement, Requirements
 def python_type_from_torch_string_repr(dtype: str):
     #  not sure this will work all the time
     return python_type_from_np_string_repr(dtype)
+
+
+logger = logging.getLogger(__name__)
 
 
 class TorchTensorDataType(
@@ -216,13 +220,15 @@ class TorchModelImport(LoadAndAnalyzeImportHook):
 
     @classmethod
     def load_obj(cls, location: Location, modifier: Optional[str], **kwargs):
-        return TorchModelIO().load(
+        torch_obj = TorchModelIO().load(
             {
                 TorchModelIO.art_name: FSSpecArtifact(
                     uri=location.uri, size=0, hash=""
                 )
             }
         )
+        logger.debug("Loaded dataframe object\n %s", torch_obj)
+        return torch_obj
 
 
 # Copyright 2019 Zyfra

--- a/mlem/core/import_objects.py
+++ b/mlem/core/import_objects.py
@@ -14,7 +14,7 @@ from mlem.core.objects import MlemData, MlemModel, MlemObject
 
 class ImportHook(Hook[MlemObject], MlemABC, ABC):
     """Base class for defining import hooks.
-    On every import attemt all available hooks are checked if the imported path
+    On every import attempt all available hooks are checked if the imported path
     represented by `Location` instance if valid for them. Then process method is
     called on a hook that first passed the check"""
 

--- a/mlem/core/metadata.py
+++ b/mlem/core/metadata.py
@@ -180,6 +180,8 @@ def load_meta(
         meta.load_value()
     if not isinstance(meta, cls):
         raise WrongMetaType(meta, force_type)
+
+    logger.debug("Loaded meta object %s", meta)
     return meta  # type: ignore[return-value]
 
 


### PR DESCRIPTION
Add some prints for verbose logging when loading various objects to help users debug their actions.
This was missing for me when investigating a behavior in `mlem apply` while working on https://github.com/iterative/mlem.ai/issues/213 - and the output was unhelpful

## Before:
```bash
❯ mlem -v apply models/rf new_data.csv -i --it "pandas[csv]"
⏳️ Importing object from new_data.csv
2022-11-06 20:14:53,954 [DEBUG] mlem.core.hooks: Registering NumpyNumberType to DataAnalyzer
2022-11-06 20:14:53,955 [DEBUG] mlem.core.hooks: Registering NumpyNdarrayType to DataAnalyzer
2022-11-06 20:14:53,956 [DEBUG] mlem.core.hooks: Not registerting _PandasDataType to any Analyzer because it's an abstract class
2022-11-06 20:14:53,957 [DEBUG] mlem.core.hooks: Registering SeriesType to DataAnalyzer
2022-11-06 20:14:53,958 [DEBUG] mlem.core.hooks: Registering DataFrameType to DataAnalyzer
2022-11-06 20:14:53,963 [DEBUG] mlem.core.hooks: Registering PandasImport to ImportAnalyzer
⏳️ Loading model from models/rf.mlem
2022-11-06 20:14:54,239 [DEBUG] mlem.core.hooks: Registering SklearnModel to ModelAnalyzer
2022-11-06 20:14:54,240 [DEBUG] mlem.core.hooks: Registering SklearnPipelineType to ModelAnalyzer
🍏 Applying `predict` method...
```

## After:
```bash
❯ mlem -v apply models/rf new_data.csv -i --it "pandas[csv]"
⏳️ Importing object from new_data.csv
2022-11-08 16:22:31,643 [DEBUG] mlem.core.hooks: Registering NumpyNumberType to DataAnalyzer
2022-11-08 16:22:31,644 [DEBUG] mlem.core.hooks: Registering NumpyNdarrayType to DataAnalyzer
2022-11-08 16:22:31,646 [DEBUG] mlem.core.hooks: Not registerting _PandasDataType to any Analyzer because it's an abstract class
2022-11-08 16:22:31,646 [DEBUG] mlem.core.hooks: Registering SeriesType to DataAnalyzer
2022-11-08 16:22:31,647 [DEBUG] mlem.core.hooks: Registering DataFrameType to DataAnalyzer
2022-11-08 16:22:31,649 [DEBUG] mlem.core.hooks: Registering PandasImport to ImportAnalyzer
2022-11-08 16:22:31,656 [DEBUG] mlem.contrib.pandas: Loaded dataframe object, showing 'describe'
        sepal length (cm)  sepal width (cm)  petal length (cm)  petal width (cm)
count                1.0               1.0                1.0               1.0
mean                 0.0               1.0                2.0               3.0
std                  NaN               NaN                NaN               NaN
min                  0.0               1.0                2.0               3.0
25%                  0.0               1.0                2.0               3.0
50%                  0.0               1.0                2.0               3.0
75%                  0.0               1.0                2.0               3.0
max                  0.0               1.0                2.0               3.0
⏳️ Loading model from models/rf.mlem
2022-11-08 16:22:31,669 [DEBUG] mlem.core.metadata: Loaded meta object location=Location(path='models/rf.mlem', project='/Users/oded/iterative/test_workspace/example-mlem-get-started', rev=None, uri='file:///Users/oded/iterative/test_workspace/example-mlem-get-started/models/rf.mlem', project_uri='file:///Users/oded/iterative/test_workspace/example-mlem-get-started/', fs=<fsspec.implementations.local.LocalFileSystem object at 0x102aa1c70>) params={} artifacts={'data': LocalArtifact(uri='rf', size=163651, hash='5276c1aecc8f1ad9e0e02305dd37c5dd')} requirements=Requirements(__root__=[InstallableRequirement(module='sklearn', version='1.1.3', package_name=None), InstallableRequirement(module='pandas', version='1.5.1', package_name=None), InstallableRequirement(module='numpy', version='1.23.4', package_name=None)]) model_type_cache={'methods': {'predict': {'args': [{'name': 'data', 'type_': {'columns': ['sepal length (cm)', 'sepal width (cm)', 'petal length (cm)', 'petal width (cm)'], 'dtypes': ['float64', 'float64', 'float64', 'float64'], 'index_cols': [], 'type': 'dataframe'}}], 'name': 'predict', 'returns': {'dtype': 'int64', 'shape': [None], 'type': 'ndarray'}}, 'predict_proba': {'args': [{'name': 'data', 'type_': {'columns': ['sepal length (cm)', 'sepal width (cm)', 'petal length (cm)', 'petal width (cm)'], 'dtypes': ['float64', 'float64', 'float64', 'float64'], 'index_cols': [], 'type': 'dataframe'}}], 'name': 'predict_proba', 'returns': {'dtype': 'float64', 'shape': [None, 3], 'type': 'ndarray'}}, 'sklearn_predict': {'args': [{'name': 'X', 'type_': {'columns': ['sepal length (cm)', 'sepal width (cm)', 'petal length (cm)', 'petal width (cm)'], 'dtypes': ['float64', 'float64', 'float64', 'float64'], 'index_cols': [], 'type': 'dataframe'}}], 'name': 'predict', 'returns': {'dtype': 'int64', 'shape': [None], 'type': 'ndarray'}}, 'sklearn_predict_proba': {'args': [{'name': 'X', 'type_': {'columns': ['sepal length (cm)', 'sepal width (cm)', 'petal length (cm)', 'petal width (cm)'], 'dtypes': ['float64', 'float64', 'float64', 'float64'], 'index_cols': [], 'type': 'dataframe'}}], 'name': 'predict_proba', 'returns': {'dtype': 'float64', 'shape': [None, 3], 'type': 'ndarray'}}}, 'type': 'sklearn'}
2022-11-08 16:22:32,215 [DEBUG] mlem.core.hooks: Registering SklearnModel to ModelAnalyzer
2022-11-08 16:22:32,216 [DEBUG] mlem.core.hooks: Registering SklearnPipelineType to ModelAnalyzer
🍏 Applying `predict` method...

```

## Note:
Didn't test pytorch objects - They should be just print the truncated for of the pytorch tensors afaik