### PR TITLE
Improve CLI telemetry

### DIFF
--- a/mlem/cli/apply.py
+++ b/mlem/cli/apply.py
@@ -27,7 +27,6 @@ from mlem.cli.utils import (
     for_each_impl,
     lazy_class_docstring,
     make_not_required,
-    pass_api_log_params,
 )
 from mlem.core.data_type import DataAnalyzer
 from mlem.core.errors import UnsupportedDataBatchLoading
@@ -35,6 +34,7 @@ from mlem.core.import_objects import ImportHook
 from mlem.core.metadata import load_meta
 from mlem.core.objects import MlemData, MlemModel
 from mlem.runtime.client import Client
+from mlem.telemetry import pass_telemetry_params
 from mlem.ui import set_echo
 from mlem.utils.entrypoints import list_implementations
 
@@ -108,15 +108,14 @@ def apply(
             )
         meta = load_meta(model, project, rev, force_type=MlemModel)
 
-        result = pass_api_log_params(
-            apply
-        )(  # pylint: disable=too-many-function-args
-            meta,
-            data,
-            method=method,
-            output=output,
-            batch_size=batch_size,
-        )
+        with pass_telemetry_params():
+            result = apply(
+                meta,
+                data,
+                method=method,
+                output=output,
+                batch_size=batch_size,
+            )
     if output is None:
         print(
             dumps(
@@ -214,6 +213,7 @@ def create_apply_remote(type_name):
         hidden=type_name.startswith("_"),
         lazy_help=lazy_class_docstring(Client.abs_name, type_name),
         no_pass_from_parent=["file_conf"],
+        is_generated_from_ext=True,
     )
     def apply_remote_func(
         data: str = option_data,
@@ -259,13 +259,11 @@ def run_apply_remote(
         load_value=True,
         force_type=MlemData,
     )
-    result = pass_api_log_params(
-        apply_remote
-    )(  # pylint: disable=too-many-function-args
-        client,
-        data,
-        method=method,
-        output=output,
-        target_project=target_project,
-    )
-    return result
+    with pass_telemetry_params():
+        return apply_remote(
+            client,
+            data,
+            method=method,
+            output=output,
+            target_project=target_project,
+        )

--- a/mlem/cli/build.py
+++ b/mlem/cli/build.py
@@ -19,10 +19,10 @@ from mlem.cli.utils import (
     for_each_impl,
     lazy_class_docstring,
     make_not_required,
-    pass_api_log_params,
 )
 from mlem.core.metadata import load_meta
 from mlem.core.objects import MlemBuilder, MlemModel
+from mlem.telemetry import pass_telemetry_params
 
 build = Typer(
     name="build",
@@ -45,16 +45,18 @@ def build_load(
 ):
     from mlem.api.commands import build
 
-    pass_api_log_params(build)(
-        config_arg(
-            MlemBuilder,
-            load,
-            None,
-            conf=None,
-            file_conf=None,
-        ),
-        load_meta(model, project, rev, force_type=MlemModel),
-    )
+    mlem_model = load_meta(model, project, rev, force_type=MlemModel)
+    with pass_telemetry_params():
+        build(
+            config_arg(
+                MlemBuilder,
+                load,
+                None,
+                conf=None,
+                file_conf=None,
+            ),
+            mlem_model,
+        )
 
 
 @for_each_impl(MlemBuilder)
@@ -70,6 +72,7 @@ def create_build_command(type_name):
         hidden=type_name.startswith("_"),
         lazy_help=lazy_class_docstring(MlemBuilder.abs_name, type_name),
         no_pass_from_parent=["file_conf"],
+        is_generated_from_ext=True,
     )
     def build_type(
         model: str = option_model,
@@ -80,14 +83,16 @@ def create_build_command(type_name):
     ):
         from mlem.api.commands import build
 
-        pass_api_log_params(build)(
-            config_arg(
-                MlemBuilder,
-                None,
-                type_name,
-                conf=None,
-                file_conf=file_conf,
-                **__kwargs__
-            ),
-            load_meta(model, project, rev, force_type=MlemModel),
-        )
+        mlem_model = load_meta(model, project, rev, force_type=MlemModel)
+        with pass_telemetry_params():
+            build(
+                config_arg(
+                    MlemBuilder,
+                    None,
+                    type_name,
+                    conf=None,
+                    file_conf=file_conf,
+                    **__kwargs__
+                ),
+                mlem_model,
+            )

--- a/mlem/cli/clone.py
+++ b/mlem/cli/clone.py
@@ -8,6 +8,7 @@ from mlem.cli.main import (
     option_rev,
     option_target_project,
 )
+from mlem.telemetry import pass_telemetry_params
 
 
 @mlem_command("clone", section="object")
@@ -23,10 +24,11 @@ def clone(
     """
     from mlem.api.commands import clone
 
-    clone(
-        uri,
-        target,
-        project=project,
-        rev=rev,
-        target_project=target_project,
-    )
+    with pass_telemetry_params():
+        clone(
+            uri,
+            target,
+            project=project,
+            rev=rev,
+            target_project=target_project,
+        )

--- a/mlem/cli/import_object.py
+++ b/mlem/cli/import_object.py
@@ -8,8 +8,8 @@ from mlem.cli.main import (
     option_rev,
     option_target_project,
 )
-from mlem.cli.utils import pass_api_log_params
 from mlem.core.import_objects import ImportHook
+from mlem.telemetry import pass_telemetry_params
 from mlem.utils.entrypoints import list_implementations
 
 
@@ -29,12 +29,13 @@ def import_object(
     """Create a `.mlem` metafile for a model or data in any file or directory."""
     from mlem.api.commands import import_object
 
-    pass_api_log_params(import_object)(
-        uri,
-        project=project,
-        rev=rev,
-        target=target,
-        target_project=target_project,
-        copy_data=copy,
-        type_=type_,
-    )
+    with pass_telemetry_params():
+        import_object(
+            uri,
+            project=project,
+            rev=rev,
+            target=target,
+            target_project=target_project,
+            copy_data=copy,
+            type_=type_,
+        )

--- a/mlem/cli/info.py
+++ b/mlem/cli/info.py
@@ -7,6 +7,7 @@ from typer import Argument, Option
 from mlem.cli.main import mlem_command, option_json, option_project, option_rev
 from mlem.core.metadata import load_meta
 from mlem.core.objects import MLEM_EXT, MlemLink, MlemObject
+from mlem.telemetry import pass_telemetry_params
 from mlem.ui import echo, set_echo
 
 OBJECT_TYPE_NAMES = {"data": "Data"}
@@ -49,7 +50,7 @@ def pretty_print(
     """Display all details about a specific MLEM Object from an existing MLEM
     project.
     """
-    with set_echo(None if json else ...):
+    with set_echo(None if json else ...), pass_telemetry_params():
         meta = load_meta(
             path, project, rev, follow_links=follow_links, load_value=False
         ).dict()

--- a/mlem/cli/init.py
+++ b/mlem/cli/init.py
@@ -1,7 +1,7 @@
 from typer import Argument
 
 from mlem.cli.main import PATH_METAVAR, mlem_command
-from mlem.cli.utils import pass_api_log_params
+from mlem.telemetry import pass_telemetry_params
 
 
 @mlem_command("init", section="common")
@@ -16,4 +16,5 @@ def init(
     """Initialize a MLEM project."""
     from mlem.api.commands import init
 
-    pass_api_log_params(init)(path)
+    with pass_telemetry_params():
+        init(path)

--- a/mlem/cli/link.py
+++ b/mlem/cli/link.py
@@ -8,7 +8,7 @@ from mlem.cli.main import (
     option_rev,
     option_target_project,
 )
-from mlem.cli.utils import pass_api_log_params
+from mlem.telemetry import pass_telemetry_params
 
 
 @mlem_command("link", section="object")
@@ -44,12 +44,13 @@ def link(
     """
     from mlem.api.commands import link
 
-    pass_api_log_params(link)(
-        source=source,
-        source_project=source_project,
-        rev=rev,
-        target=target,
-        target_project=target_project,
-        follow_links=follow_links,
-        absolute=absolute,
-    )
+    with pass_telemetry_params():
+        link(
+            source=source,
+            source_project=source_project,
+            rev=rev,
+            target=target,
+            target_project=target_project,
+            follow_links=follow_links,
+            absolute=absolute,
+        )

--- a/mlem/cli/serve.py
+++ b/mlem/cli/serve.py
@@ -19,11 +19,11 @@ from mlem.cli.utils import (
     for_each_impl,
     lazy_class_docstring,
     make_not_required,
-    pass_api_log_params,
 )
 from mlem.core.metadata import load_meta
 from mlem.core.objects import MlemModel
 from mlem.runtime.server import Server
+from mlem.telemetry import pass_telemetry_params
 
 serve = Typer(
     name="serve",
@@ -50,17 +50,18 @@ def serve_load(
 ):
     from mlem.api.commands import serve
 
-    pass_api_log_params(serve)(
-        load_meta(model, project, rev, force_type=MlemModel),
-        config_arg(
-            Server,
-            load,
-            None,
-            conf=None,
-            file_conf=None,
-        ),
-        standardize=standartize,
-    )
+    with pass_telemetry_params():
+        serve(
+            load_meta(model, project, rev, force_type=MlemModel),
+            config_arg(
+                Server,
+                load,
+                None,
+                conf=None,
+                file_conf=None,
+            ),
+            standardize=standartize,
+        )
 
 
 @for_each_impl(Server)
@@ -74,6 +75,7 @@ def create_serve_command(type_name):
         hidden=type_name.startswith("_"),
         lazy_help=lazy_class_docstring(Server.abs_name, type_name),
         no_pass_from_parent=["file_conf"],
+        is_generated_from_ext=True,
     )
     def serve_command(
         model: str = option_model,
@@ -85,15 +87,17 @@ def create_serve_command(type_name):
     ):
         from mlem.api.commands import serve
 
-        serve(
-            load_meta(model, project, rev, force_type=MlemModel),
-            config_arg(
-                Server,
-                None,
-                type_name,
-                conf=None,
-                file_conf=file_conf,
-                **__kwargs__
-            ),
-            standardize=standartize,
-        )
+        mlem_model = load_meta(model, project, rev, force_type=MlemModel)
+        with pass_telemetry_params():
+            serve(
+                mlem_model,
+                config_arg(
+                    Server,
+                    None,
+                    type_name,
+                    conf=None,
+                    file_conf=file_conf,
+                    **__kwargs__
+                ),
+                standardize=standartize,
+            )

--- a/mlem/cli/utils.py
+++ b/mlem/cli/utils.py
@@ -61,10 +61,6 @@ def is_cli():
     return _is_cli
 
 
-def pass_api_log_params(f):
-    return getattr(f, "__wrapped__", f)
-
-
 def mark_as_cli():
     global _is_cli  # pylint: disable=global-statement
     _is_cli = True

--- a/mlem/telemetry.py
+++ b/mlem/telemetry.py
@@ -1,3 +1,4 @@
+import contextlib
 from functools import wraps
 
 from iterative_telemetry import IterativeTelemetryLogger
@@ -18,23 +19,52 @@ telemetry = IterativeTelemetryLogger(
     url="https://telemetry.mlem.dev/api/v1/s2s/event?ip_policy=strict",
 )
 
-
 _is_api_running = False
+_pass_params = False
+
+
+@contextlib.contextmanager
+def pass_telemetry_params():
+    global _pass_params  # pylint: disable=global-statement
+    pass_params = _pass_params
+    try:
+        _pass_params = True
+        yield
+    finally:
+        _pass_params = pass_params
 
 
 def api_telemetry(f):
     @wraps(f)
     def inner(*args, **kwargs):
-        global _is_api_running  # pylint: disable=global-statement
+        global _is_api_running, _pass_params  # pylint: disable=global-statement
         is_nested = _is_api_running
+        pass_params = _pass_params
+        _pass_params = False
         _is_api_running = True
         try:
             from mlem.cli.utils import is_cli
 
-            return telemetry.log("api", skip=is_nested or is_cli())(f)(
-                *args, **kwargs
-            )
+            with telemetry.event_scope("api", f.__name__) as event:
+                try:
+                    return f(*args, **kwargs)
+                except Exception as exc:
+                    event.error = exc.__class__.__name__
+                    raise
+                finally:
+                    if not is_nested and not is_cli():
+                        telemetry.send_event(
+                            event.interface,
+                            event.action,
+                            event.error,
+                            **event.kwargs,
+                        )
+
         finally:
+            if pass_params:
+                for key, value in event.kwargs.items():
+                    telemetry.log_param(key, value)
             _is_api_running = is_nested
+            _pass_params = pass_params
 
     return inner


### PR DESCRIPTION
1. better passing params from API
2. cli actions do not include dynamic subcommands (instead they are loggen in params now)