### PR TITLE
Fix `deploy` requiring `requirements` to be installed

### DIFF
--- a/.github/workflows/check-test-release.yml
+++ b/.github/workflows/check-test-release.yml
@@ -90,10 +90,27 @@ jobs:
         brew install hdf5 wget c-blosc
         wget https://raw.githubusercontent.com/Homebrew/homebrew-core/fb8323f2b170bd4ae97e1bac9bf3e2983af3fdb0/Formula/libomp.rb
         brew install ./libomp.rb
-    - name: Install
-      if: steps.cache.pip-cache-dir.cache-hit != 'true'
+    - name: Install MLEM
+      if: steps.cache.pip-cache.cache-hit != 'true'
       run: |
         pip install --upgrade pip setuptools wheel
+        pip install .
+    - name: Run Heroku tests
+      if: |
+        matrix.os == 'ubuntu-latest' &&
+        matrix.python == '3.8' &&
+        (
+          github.event_name == 'schedule' ||
+          contains(github.event.pull_request.title, 'heroku')
+        )
+      timeout-minutes: 40
+      run: pytest -k 'heroku'
+      env:
+        HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+        HEROKU_TEAM: iterative-sandbox
+    - name: Install extra dependencies
+      if: steps.cache.pip-cache.cache-hit != 'true'
+      run: |
         pip install pre-commit .[tests]
     - if: matrix.os == 'ubuntu-latest' && matrix.python == '3.10'
       run: pre-commit run pylint -a -v --show-diff-on-failure
@@ -112,19 +129,6 @@ jobs:
         GITHUB_MATRIX_PYTHON: ${{ matrix.python }}
         BITBUCKET_USERNAME: ${{ secrets.BITBUCKET_USERNAME }}
         BITBUCKET_PASSWORD: ${{ secrets.BITBUCKET_PASSWORD }}
-    - name: Run Heroku tests
-      if: |
-        matrix.os == 'ubuntu-latest' &&
-        matrix.python == '3.8' &&
-        (
-          github.event_name == 'schedule' ||
-          contains(github.event.pull_request.title, 'heroku')
-        )
-      timeout-minutes: 40
-      run: pytest -k 'heroku'
-      env:
-        HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
-        HEROKU_TEAM: iterative-sandbox
     - name: "Upload coverage to Codecov"
       uses: codecov/codecov-action@v3
       with:

--- a/.github/workflows/check-test-release.yml
+++ b/.github/workflows/check-test-release.yml
@@ -73,14 +73,14 @@ jobs:
         python-version: ${{ matrix.python }}
         activate-environment: true
     - name: get pip cache dir
-      id: pip-cache-dir
+      id: cache-dir
       run: |
         echo "::set-output name=dir::$(pip cache dir)"
     - name: set pip cache
-      id: pip-cache
+      id: cache
       uses: actions/cache@v3.0.11
       with:
-        path: ${{ steps.pip-cache-dir.outputs.dir }}
+        path: ${{ steps.cache-dir.outputs.dir }}
         key: ${{ runner.os }}-pip-${{ hashFiles('setup.cfg') }}
         restore-keys: |
           ${{ runner.os }}-pip-
@@ -91,7 +91,7 @@ jobs:
         wget https://raw.githubusercontent.com/Homebrew/homebrew-core/fb8323f2b170bd4ae97e1bac9bf3e2983af3fdb0/Formula/libomp.rb
         brew install ./libomp.rb
     - name: Install MLEM
-      if: steps.cache.pip-cache.cache-hit != 'true'
+      if: steps.cache.outputs.cache-hit != 'true'
       run: |
         pip install --upgrade pip setuptools wheel
         pip install .
@@ -109,7 +109,7 @@ jobs:
         HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
         HEROKU_TEAM: iterative-sandbox
     - name: Install extra dependencies
-      if: steps.cache.pip-cache.cache-hit != 'true'
+      if: steps.cache.outputs.cache-hit != 'true'
       run: |
         pip install pre-commit .[tests]
     - if: matrix.os == 'ubuntu-latest' && matrix.python == '3.10'

--- a/.github/workflows/check-test-release.yml
+++ b/.github/workflows/check-test-release.yml
@@ -72,12 +72,6 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
         activate-environment: true
-    - name: Install Mac-specific dependencies
-      if: matrix.os == 'macos-latest'
-      run: |
-        brew install hdf5 wget c-blosc
-        wget https://raw.githubusercontent.com/Homebrew/homebrew-core/fb8323f2b170bd4ae97e1bac9bf3e2983af3fdb0/Formula/libomp.rb
-        brew install ./libomp.rb
     - name: get pip cache dir
       id: cache-dir
       run: |
@@ -91,10 +85,18 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
         restore-keys: |
           ${{ runner.os }}-pip-
+    - name: Install Mac-specific dependencies
+      if: matrix.os == 'macos-latest'
+      run: |
+        brew install hdf5 wget c-blosc
+        wget https://raw.githubusercontent.com/Homebrew/homebrew-core/fb8323f2b170bd4ae97e1bac9bf3e2983af3fdb0/Formula/libomp.rb
+        brew install ./libomp.rb
     - name: Install
       run: |
         pip install --upgrade pip setuptools wheel
         pip install pre-commit .[tests]
+    - if: matrix.os == 'ubuntu-latest' && matrix.python == '3.10'
+      run: pre-commit run pylint -a -v --show-diff-on-failure
     - name: Run Heroku tests
       if: |
         matrix.os == 'ubuntu-latest' &&
@@ -108,12 +110,10 @@ jobs:
       env:
         HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
         HEROKU_TEAM: iterative-sandbox
-    - if: matrix.os == 'ubuntu-latest' && matrix.python == '3.10'
-      run: pre-commit run pylint -a -v --show-diff-on-failure
     - name: Start minikube
       if: matrix.os == 'ubuntu-latest' && matrix.python == '3.9'
       uses: medyagh/setup-minikube@master
-    - name: Run all other tests
+    - name: Run tests
       timeout-minutes: 40
       run: pytest -k 'not heroku'
       env:

--- a/.github/workflows/check-test-release.yml
+++ b/.github/workflows/check-test-release.yml
@@ -39,6 +39,10 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
+    - uses: actions/cache@v3
+      with:
+        path: ~/.cache/pre-commit
+        key: pre-commit
     - run: pip install -U pre-commit tox
     - run: SKIP=pylint pre-commit run -a --show-diff-on-failure
   test:
@@ -72,11 +76,21 @@ jobs:
         brew install hdf5 wget c-blosc
         wget https://raw.githubusercontent.com/Homebrew/homebrew-core/fb8323f2b170bd4ae97e1bac9bf3e2983af3fdb0/Formula/libomp.rb
         brew install ./libomp.rb
-    - name: Install MLEM
+    - name: get pip cache dir
+      id: cache-dir
+      run: |
+        echo "::set-output name=dir::$(pip cache dir)"
+    - name: set pip cache
+      id: cache
+      uses: actions/cache@v3.0.11
+      with:
+        path: ${{ steps.cache-dir.outputs.dir }}
+        key: ${{ runner.os }}-pip
+    - name: Install MLEM without dependencies
       run: |
         pip install --upgrade pip setuptools wheel
         pip install .
-    - name: Run Heroku tests
+    - name: Run Heroku tests # add all build/deploy tests here?
       if: |
         matrix.os == 'ubuntu-latest' &&
         matrix.python == '3.8' &&

--- a/.github/workflows/check-test-release.yml
+++ b/.github/workflows/check-test-release.yml
@@ -91,12 +91,10 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
         restore-keys: |
           ${{ runner.os }}-pip-
-    - name: Install MLEM only to run tests that must not require extra dependencies
+    - name: Install
       run: |
         pip install --upgrade pip setuptools wheel
-        pip install .
-    - name: Run Docker and K8s tests
-      run: pytest -k 'docker or kubernetes'
+        pip install pre-commit .[tests]
     - name: Run Heroku tests
       if: |
         matrix.os == 'ubuntu-latest' &&
@@ -110,8 +108,6 @@ jobs:
       env:
         HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
         HEROKU_TEAM: iterative-sandbox
-    - name: Install extra dependencies to run all tests that left
-      run: pip install pre-commit .[tests]
     - if: matrix.os == 'ubuntu-latest' && matrix.python == '3.10'
       run: pre-commit run pylint -a -v --show-diff-on-failure
     - name: Start minikube
@@ -119,7 +115,7 @@ jobs:
       uses: medyagh/setup-minikube@master
     - name: Run all other tests
       timeout-minutes: 40
-      run: pytest -k 'not heroku and not docker and not kubernetes'
+      run: pytest -k 'not heroku'
       env:
         GITHUB_USERNAME: ${{ secrets.GH_USERNAME }}
         GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/check-test-release.yml
+++ b/.github/workflows/check-test-release.yml
@@ -91,10 +91,12 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
         restore-keys: |
           ${{ runner.os }}-pip-
-    - name: Install MLEM
+    - name: Install MLEM only to run tests that must not require extra dependencies
       run: |
         pip install --upgrade pip setuptools wheel
         pip install .
+    - name: Run Docker and K8s tests
+      run: pytest -k 'docker or kubernetes'
     - name: Run Heroku tests
       if: |
         matrix.os == 'ubuntu-latest' &&
@@ -108,17 +110,16 @@ jobs:
       env:
         HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
         HEROKU_TEAM: iterative-sandbox
-    - name: Install extra dependencies
-      run: |
-        pip install pre-commit .[tests]
+    - name: Install extra dependencies to run all tests that left
+      run: pip install pre-commit .[tests]
     - if: matrix.os == 'ubuntu-latest' && matrix.python == '3.10'
       run: pre-commit run pylint -a -v --show-diff-on-failure
     - name: Start minikube
       if: matrix.os == 'ubuntu-latest' && matrix.python == '3.9'
       uses: medyagh/setup-minikube@master
-    - name: Run tests
+    - name: Run all other tests
       timeout-minutes: 40
-      run: pytest -k 'not heroku'
+      run: pytest -k 'not heroku and not docker and not kubernetes'
       env:
         GITHUB_USERNAME: ${{ secrets.GH_USERNAME }}
         GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/check-test-release.yml
+++ b/.github/workflows/check-test-release.yml
@@ -39,10 +39,12 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
+    - name: set PYSHA
+      run: echo "PYSHA=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
     - uses: actions/cache@v3
       with:
         path: ~/.cache/pre-commit
-        key: pre-commit
+        key: pre-commit|${{ env.PYSHA }}|${{ hashFiles('.pre-commit-config.yaml') }}
     - run: pip install -U pre-commit tox
     - run: SKIP=pylint pre-commit run -a --show-diff-on-failure
   test:
@@ -85,12 +87,15 @@ jobs:
       uses: actions/cache@v3.0.11
       with:
         path: ${{ steps.cache-dir.outputs.dir }}
-        key: ${{ runner.os }}-pip
-    - name: Install MLEM without dependencies
+        # setup.py is used here to sometimes start using new cache, getting rid of old useless packages
+        key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+    - name: Install MLEM
       run: |
         pip install --upgrade pip setuptools wheel
         pip install .
-    - name: Run Heroku tests # add all build/deploy tests here?
+    - name: Run Heroku tests
       if: |
         matrix.os == 'ubuntu-latest' &&
         matrix.python == '3.8' &&

--- a/.github/workflows/check-test-release.yml
+++ b/.github/workflows/check-test-release.yml
@@ -72,18 +72,6 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
         activate-environment: true
-    - name: get pip cache dir
-      id: cache-dir
-      run: |
-        echo "::set-output name=dir::$(pip cache dir)"
-    - name: set pip cache
-      id: cache
-      uses: actions/cache@v3.0.11
-      with:
-        path: ${{ steps.cache-dir.outputs.dir }}
-        key: ${{ runner.os }}-pip-${{ hashFiles('setup.cfg') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
     - name: Install Mac-specific dependencies
       if: matrix.os == 'macos-latest'
       run: |
@@ -108,6 +96,18 @@ jobs:
       env:
         HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
         HEROKU_TEAM: iterative-sandbox
+    - name: get pip cache dir
+      id: cache-dir
+      run: |
+        echo "::set-output name=dir::$(pip cache dir)"
+    - name: set pip cache
+      id: cache
+      uses: actions/cache@v3.0.11
+      with:
+        path: ${{ steps.cache-dir.outputs.dir }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('setup.cfg') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
     - name: Install extra dependencies
       if: steps.cache.outputs.cache-hit != 'true'
       run: |

--- a/.github/workflows/check-test-release.yml
+++ b/.github/workflows/check-test-release.yml
@@ -39,12 +39,6 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
-    - name: set PYSHA
-      run: echo "PYSHA=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
-    - uses: actions/cache@v3
-      with:
-        path: ~/.cache/pre-commit
-        key: pre-commit|${{ env.PYSHA }}|${{ hashFiles('.pre-commit-config.yaml') }}
     - run: pip install -U pre-commit tox
     - run: SKIP=pylint pre-commit run -a --show-diff-on-failure
   test:
@@ -79,7 +73,6 @@ jobs:
         wget https://raw.githubusercontent.com/Homebrew/homebrew-core/fb8323f2b170bd4ae97e1bac9bf3e2983af3fdb0/Formula/libomp.rb
         brew install ./libomp.rb
     - name: Install MLEM
-      if: steps.cache.outputs.cache-hit != 'true'
       run: |
         pip install --upgrade pip setuptools wheel
         pip install .
@@ -96,20 +89,7 @@ jobs:
       env:
         HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
         HEROKU_TEAM: iterative-sandbox
-    - name: get pip cache dir
-      id: cache-dir
-      run: |
-        echo "::set-output name=dir::$(pip cache dir)"
-    - name: set pip cache
-      id: cache
-      uses: actions/cache@v3.0.11
-      with:
-        path: ${{ steps.cache-dir.outputs.dir }}
-        key: ${{ runner.os }}-pip-${{ hashFiles('setup.cfg') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
     - name: Install extra dependencies
-      if: steps.cache.outputs.cache-hit != 'true'
       run: |
         pip install pre-commit .[tests]
     - if: matrix.os == 'ubuntu-latest' && matrix.python == '3.10'

--- a/mlem/api/commands.py
+++ b/mlem/api/commands.py
@@ -475,7 +475,7 @@ def deploy(
     # ensuring links are working
     log_meta_params(deploy_meta)
     deploy_meta.get_env()
-    model_meta = get_model_meta(model)
+    model_meta = get_model_meta(model, load_value=False)
     log_meta_params(model_meta)
 
     deploy_meta.check_unchanged()

--- a/tests/cli/test_deployment.py
+++ b/tests/cli/test_deployment.py
@@ -189,6 +189,9 @@ def test_deploy_create_new(
     runner: Runner, model_meta_saved_single, mock_env_path, tmp_path
 ):
     path = os.path.join(tmp_path, "deployname")
+    # rewrite pickled model to check it's not loaded
+    with open(model_meta_saved_single.loc.path[: -len(MLEM_EXT)], "wb") as f:
+        f.write(b"")
     result = runner.invoke(
         f"deploy run {MlemDeploymentMock.type} {path} -m {model_meta_saved_single.loc.uri} --env {mock_env_path} --param aaa".split()
     )


### PR DESCRIPTION
close #550

Ok, we need some tests for this. It will require a separate step in CI job - changing the workflow.

We should check that both `mlem deploy` and `mlem build` do their thing.

Created dummy PR that will run CI from this exact branch will changes that I introduced: https://github.com/iterative/mlem/pull/556