### PR TITLE
Fix bug with serving models without `model`, with processors only

### DIFF
--- a/mlem/api/utils.py
+++ b/mlem/api/utils.py
@@ -31,8 +31,8 @@ def get_model_meta(
     model: Union[str, MlemModel], load_value: bool = True
 ) -> MlemModel:
     if isinstance(model, MlemModel):
-        if load_value and model.get_value() is None:
-            model.load_value()
+        if load_value:
+            model.load_value(skip_loaded=True)
         return model
     if isinstance(model, str):
         model = load_meta(model, force_type=MlemModel)

--- a/mlem/core/objects.py
+++ b/mlem/core/objects.py
@@ -649,7 +649,10 @@ class MlemModel(_WithArtifacts):
 
     @property
     def is_single_model(self):
-        return len(self.processors_cache) == 1
+        return (
+            len(self.processors_cache) == 1
+            and MAIN_PROCESSOR_NAME in self.processors
+        )
 
     def _create_processor(self, obj: Any, sample_data: Any, name: str):
         model_type = ModelAnalyzer.analyze(obj, sample_data=sample_data).bind(
@@ -826,7 +829,7 @@ class MlemModel(_WithArtifacts):
 
     def load_value(self, skip_loaded=True):
         with self.requirements.import_custom():
-            if len(self.processors_cache) == 1:
+            if self.is_single_model:
                 if not skip_loaded or self.model_type.model is None:
                     self.model_type.load(self.relative_artifacts)
             else:

--- a/mlem/core/objects.py
+++ b/mlem/core/objects.py
@@ -824,13 +824,15 @@ class MlemModel(_WithArtifacts):
             ).items()
         }
 
-    def load_value(self):
+    def load_value(self, skip_loaded=True):
         with self.requirements.import_custom():
             if len(self.processors_cache) == 1:
-                self.model_type.load(self.relative_artifacts)
+                if not skip_loaded or self.model_type.model is None:
+                    self.model_type.load(self.relative_artifacts)
             else:
                 for name, processor in self.processors.items():
-                    processor.load(self.relative_processor_artifacts(name))
+                    if not skip_loaded or processor.model is None:
+                        processor.load(self.relative_processor_artifacts(name))
 
     def relative_processor_artifacts(self, name):
         return {

--- a/tests/api/test_utils.py
+++ b/tests/api/test_utils.py
@@ -6,24 +6,43 @@ from mlem.api.utils import get_model_meta
 from mlem.core.objects import MlemModel, ModelAnalyzer
 
 
-@pytest.fixture
-def custom_processors_model(tmp_path: PosixPath):
-    def funclen(x):
-        return len(x)
+def funclen(x):
+    return len(x)
 
+
+@pytest.fixture
+def one_custom_processor_model(tmp_path: PosixPath):
     model = MlemModel()
     model.add_processor(
-        "explain", ModelAnalyzer.analyze(funclen, sample_data="word")
+        "textlen", ModelAnalyzer.analyze(funclen, sample_data="word")
     )
-    model.add_processor(
-        "guess", ModelAnalyzer.analyze(funclen, sample_data="word")
-    )
-    model.call_orders["explain"] = [("explain", "__call__")]
-    model.call_orders["guess"] = [("guess", "__call__")]
+    model.call_orders["textlen"] = [("textlen", "__call__")]
     path = str(tmp_path / "model")
     model.dump(path)
     return path
 
 
-def test_get_model_meta(custom_processors_model):
-    get_model_meta(custom_processors_model, load_value=True)
+@pytest.fixture
+def two_custom_processors_model(tmp_path: PosixPath):
+    model = MlemModel()
+    model.add_processor(
+        "textlen", ModelAnalyzer.analyze(funclen, sample_data="word")
+    )
+    model.call_orders["textlen"] = [("textlen", "__call__")]
+    model.add_processor(
+        "textlen2", ModelAnalyzer.analyze(funclen, sample_data="word")
+    )
+    model.call_orders["textlen2"] = [("textlen2", "__call__")]
+    path = str(tmp_path / "model")
+    model.dump(path)
+    return path
+
+
+def test_get_model_meta_one_processor(one_custom_processor_model):
+    model = get_model_meta(one_custom_processor_model, load_value=True)
+    assert model.textlen("tenletters") == 10
+
+
+def test_get_model_meta_two_processors(two_custom_processors_model):
+    model = get_model_meta(two_custom_processors_model, load_value=True)
+    assert model.textlen("tenletters") == 10

--- a/tests/api/test_utils.py
+++ b/tests/api/test_utils.py
@@ -1,0 +1,29 @@
+from pathlib import PosixPath
+
+import pytest
+
+from mlem.api.utils import get_model_meta
+from mlem.core.objects import MlemModel, ModelAnalyzer
+
+
+@pytest.fixture
+def custom_processors_model(tmp_path: PosixPath):
+    def funclen(x):
+        return len(x)
+
+    model = MlemModel()
+    model.add_processor(
+        "explain", ModelAnalyzer.analyze(funclen, sample_data="word")
+    )
+    model.add_processor(
+        "guess", ModelAnalyzer.analyze(funclen, sample_data="word")
+    )
+    model.call_orders["explain"] = [("explain", "__call__")]
+    model.call_orders["guess"] = [("guess", "__call__")]
+    path = str(tmp_path / "model")
+    model.dump(path)
+    return path
+
+
+def test_get_model_meta(custom_processors_model):
+    get_model_meta(custom_processors_model, load_value=True)


### PR DESCRIPTION
Example it was breaking on
```py
from mlem.core.objects import MlemModel, ModelAnalyzer


model = MlemModel()
model.add_processor("explain", ModelAnalyzer.analyze(lambda x: len(x), sample_data="word"))
model.add_processor("guess", ModelAnalyzer.analyze(lambda x: len(x), sample_data="word"))
model.call_orders["explain"] = [("explain", "__call__")]
model.call_orders["guess"] = [("guess", "__call__")]

model.dump("player")
```

```shell
$ mlem serve streamlit --model player
```