### PR TITLE
Allow rerunning `deploy` without `--load` if deployment meta is going to be the same

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,7 @@ ignore =
     P1,   # unindexed parameters in the str.format, see:
     B902, # Invalid first argument 'cls' used for instance method.
     B024, # ABCs without methods
+    B028, # Use f"{obj!r}" instead of f"'{obj}'"
     # https://pypi.org/project/flake8-string-format/
 max_line_length = 79
 max-complexity = 15

--- a/tests/cli/test_deployment.py
+++ b/tests/cli/test_deployment.py
@@ -205,6 +205,24 @@ def test_deploy_create_new(
     assert isinstance(meta, MlemDeploymentMock)
     assert meta.param == "aaa"
     assert meta.get_status() == DeployStatus.RUNNING
+    # test you can run the same command without error
+    result = runner.invoke(
+        f"deploy run {MlemDeploymentMock.type} {path} -m {model_meta_saved_single.loc.uri} --env {mock_env_path} --param aaa".split()
+    )
+    assert result.exit_code == 0, (
+        result.stdout,
+        result.stderr,
+        result.exception,
+    )
+    # but if you change deployment params, you'll have an error
+    result = runner.invoke(
+        f"deploy run {MlemDeploymentMock.type} {path} -m {model_meta_saved_single.loc.uri} --env {mock_env_path} --param bbb".split()
+    )
+    assert result.exit_code == 1, (
+        result.stdout,
+        result.stderr,
+        result.exception,
+    )
 
 
 def test_deploy_create_existing(


### PR DESCRIPTION
If meta is different, it will error out now
```
$ mlem deploy run heroku heroku.mlem --model player --app_name hat-player2
⏳️ Loading deployment from heroku.mlem
❌ Different deployment meta already exists at path='/Users/aguschin/Git/iterative/mlem/hat-player/heroku.mlem' project=None rev=None
uri='file:///Users/aguschin/Git/iterative/mlem/hat-player/heroku.mlem' project_uri=None fs=<fsspec.implementations.local.LocalFileSystem object at
0x10c230760>. Please use `mlem deployment run --load <path> ...`
```
but if it's the same, it will go on:
```
$ mlem --tb deploy run heroku heroku.mlem --model player --app_name hat-player
⏳️ Loading deployment from heroku.mlem
⏳️ Loading model from player.mlem
🛠 Creating docker image for heroku
...
```

see https://github.com/iterative/mlem/issues/463#issuecomment-1325156631 for discussion