### PR TITLE
Fix IndexError on missing CLI arg

### DIFF
--- a/mlem/cli/main.py
+++ b/mlem/cli/main.py
@@ -16,7 +16,14 @@ from typing import (
 
 import click
 import typer
-from click import Abort, ClickException, Command, HelpFormatter, Parameter
+from click import (
+    Abort,
+    Argument,
+    ClickException,
+    Command,
+    HelpFormatter,
+    Parameter,
+)
 from click.exceptions import Exit, MissingParameter, NoSuchOption
 from pydantic import ValidationError
 from typer import Context, Option, Typer
@@ -144,20 +151,41 @@ class MlemCommand(
         ctx = super().make_context(info_name, args, parent, **extra)
         if not self.dynamic_options_generator:
             return ctx
-        extra_args = ctx.args
+        argument_params = {
+            a.name for a in self.get_params(ctx) if isinstance(a, Argument)
+        }
         params = ctx.params.copy()
+        extra_args = get_extra_keys(
+            ctx.args
+            + [
+                v
+                for k, v in params.items()
+                if k in argument_params and v.startswith("--")
+            ]
+        )
         while extra_args:
+            params = {
+                k: v for k, v in params.items() if k not in argument_params
+            }
             ctx.params = params
             ctx.args = args_copy[:]
             with ctx.scope(cleanup=False):
                 self.parse_args(ctx, args_copy[:])
                 params.update(ctx.params)
 
-            if ctx.args == extra_args:
+            new_extra_args = get_extra_keys(
+                ctx.args
+                + [
+                    v
+                    for k, v in params.items()
+                    if k in argument_params and v.startswith("--")
+                ]
+            )
+            if new_extra_args == extra_args:
                 if not self.ignore_unknown_options:
                     from difflib import get_close_matches
 
-                    opt = "--" + get_extra_keys(extra_args)[0]
+                    opt = "--" + new_extra_args[0]
                     possibilities = get_close_matches(
                         opt, {f"--{o}" for o in params}
                     )
@@ -165,7 +193,8 @@ class MlemCommand(
                         opt, possibilities=possibilities, ctx=ctx
                     )
                 break
-            extra_args = ctx.args
+
+            extra_args = new_extra_args
 
         return ctx
 

--- a/tests/cli/test_declare.py
+++ b/tests/cli/test_declare.py
@@ -573,3 +573,11 @@ def test_declare_unknown_option_raises(runner: Runner):
             f"--tb declare deployment {MlemDeploymentMock.type} nowhere --nonexistent_option value",
             raise_on_error=True,
         )
+
+
+def test_declare_missing_arg_raises(runner: Runner):
+    with pytest.raises(RuntimeError, match=".*Missing argument.*"):
+        runner.invoke(
+            f"--tb declare deployment {MlemDeploymentMock.type}  --param value",
+            raise_on_error=True,
+        )


### PR DESCRIPTION
The bug was actually that option name (`--image.name`) was considered a value for ARG and error happened after when mlem tried to raise en error for not parsed option, which was actually a value for `--image.name`

The fix is that now we look at parsed arguments and if they start with `--` we consider it as mistakenly parsed option name instead

closes #544