### PR TITLE
Fixing small typo in the CLI

### DIFF
--- a/mlem/cli/serve.py
+++ b/mlem/cli/serve.py
@@ -33,12 +33,13 @@ serve = Typer(
 )
 app.add_typer(serve)
 
-option_standartize = Option(
+# Include "--standartize" for historical compatability
+option_standardize = Option(
     True,
+    "--standardize/--no-standardize",
     "--standartize/--no-standartize",
     help="Whether to conform model interface to standard ('predict' method with single arg 'data')",
 )
-
 
 @mlem_group_callback(serve, required=["model", "load"])
 def serve_load(
@@ -46,7 +47,7 @@ def serve_load(
     project: Optional[str] = option_project,
     rev: Optional[str] = option_rev,
     load: Optional[str] = option_load("server"),
-    standartize: bool = option_standartize,
+    standardize: bool = option_standardize,
 ):
     from mlem.api.commands import serve
 
@@ -60,7 +61,7 @@ def serve_load(
                 conf=None,
                 file_conf=None,
             ),
-            standardize=standartize,
+            standardize=standardize,
         )
 
 
@@ -82,7 +83,7 @@ def create_serve_command(type_name):
         project: Optional[str] = option_project,
         rev: Optional[str] = option_rev,
         file_conf: List[str] = option_file_conf("server"),
-        standartize: bool = option_standartize,
+        standardize: bool = option_standardize,
         **__kwargs__
     ):
         from mlem.api.commands import serve
@@ -99,5 +100,5 @@ def create_serve_command(type_name):
                     file_conf=file_conf,
                     **__kwargs__
                 ),
-                standardize=standartize,
+                standardize=standardize,
             )

--- a/mlem/cli/serve.py
+++ b/mlem/cli/serve.py
@@ -41,6 +41,7 @@ option_standardize = Option(
     help="Whether to conform model interface to standard ('predict' method with single arg 'data')",
 )
 
+
 @mlem_group_callback(serve, required=["model", "load"])
 def serve_load(
     model: str = make_not_required(option_model),

--- a/mlem/cli/utils.py
+++ b/mlem/cli/utils.py
@@ -534,7 +534,7 @@ def lazy_class_docstring(abs_name: str, type_name: str):
         try:
             return load_impl_ext(abs_name, type_name).__doc__
         except ExtensionRequirementError as e:
-            return f"Help unavailbale: {e}"
+            return f"Help unavailable: {e}"
 
     return load_docstring
 


### PR DESCRIPTION
This fixes a typo in the `--standartize` argument of `mlem serve`.  A few details:

- The way I've implemented it, `mlem serve` now accepts both `--standardize/--no-standardize` and `--standartize/--no-standartize` to avoid breaking changes.  Fortunately this is pretty simple to do with `typer`.
- I noticed that before this change, the variable `standartize` was being passed to `Server` via `**kwargs`, while `Server` [was expecting the parameter `standardize`](https://github.com/iterative/mlem/blob/c7f91613b7a71a09dcbfb79c6254346f181d4a32/mlem/runtime/server.py#L174). So passing `--no-standardize` actually had no effect on the server.  Not sure how important that is 🤷 
- I'm happy to add tests, but the logic seems a little tangled and tricky to test and I could use a little help if you think testing is worth it.


Closes #579 