### PR TITLE
`serve fastapi`: expose `/metrics` endpoint for Prometheus

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ extras = {
     "catboost": ["catboost"],
     "xgboost": ["xgboost"],
     "lightgbm": ["lightgbm"],
-    "fastapi": ["uvicorn", "fastapi"],
+    "fastapi": ["uvicorn", "fastapi", "prometheus-fastapi-instrumentator"],
     "streamlit": ["uvicorn", "fastapi", "streamlit", "streamlit_pydantic"],
     "sagemaker": ["docker", "boto3", "sagemaker"],
     "torch": ["torch"],


### PR DESCRIPTION
This PR adds an option to expose `/metrics` endpoint to be scraped by Prometheus, when a model is served with FastAPI.

related to #429 and https://github.com/iterative/mlem/issues/589

The result looks like 
<img width="578" alt="image" src="https://user-images.githubusercontent.com/6797716/214001823-6e574334-2d2c-49b8-b441-6ffb5de0fffa.png">
