### PR TITLE
Add server field to heroku deploy

### DIFF
--- a/mlem/contrib/fastapi.py
+++ b/mlem/contrib/fastapi.py
@@ -53,6 +53,7 @@ class FastAPIServer(Server, LibRequirementsMixin):
 
     libraries: ClassVar[List[ModuleType]] = [uvicorn, fastapi]
     type: ClassVar[str] = "fastapi"
+    port_field: ClassVar = "port"
 
     host: str = "0.0.0.0"
     """Network interface to use"""

--- a/mlem/contrib/heroku/build.py
+++ b/mlem/contrib/heroku/build.py
@@ -3,8 +3,9 @@ from typing import ClassVar, Optional
 
 from mlem.core.objects import MlemModel
 
+from ...runtime.server import Server
 from ...ui import EMOJI_BUILD, echo, set_offset
-from ..docker.base import DockerEnv, DockerImage, RemoteRegistry
+from ..docker.base import DockerImage, RemoteRegistry
 from ..docker.helpers import build_model_image
 from .server import HerokuServer
 
@@ -41,23 +42,21 @@ class HerokuRemoteRegistry(RemoteRegistry):
 
 def build_heroku_docker(
     meta: MlemModel,
+    server: Server,
     app_name: str,
     process_type: str = "web",
     api_key: str = None,
     push: bool = True,
 ) -> DockerImage:
-    docker_env = DockerEnv(
-        registry=HerokuRemoteRegistry(
-            host="registry.heroku.com", api_key=api_key
-        )
-    )
     echo(EMOJI_BUILD + "Creating docker image for heroku")
     with set_offset(2):
         return build_model_image(
             meta,
             process_type,
-            server=HerokuServer(),
-            env=docker_env,
+            server=HerokuServer(server=server),
+            registry=HerokuRemoteRegistry(
+                host="registry.heroku.com", api_key=api_key
+            ),
             repository=app_name,
             force_overwrite=True,
             # heroku does not support arm64 images built on Mac M1 devices

--- a/mlem/contrib/heroku/server.py
+++ b/mlem/contrib/heroku/server.py
@@ -2,18 +2,34 @@ import logging
 import os
 from typing import ClassVar
 
-from mlem.contrib.fastapi import FastAPIServer
+from pydantic import validator
+
 from mlem.runtime import Interface
+from mlem.runtime.server import Server
 
 logger = logging.getLogger(__name__)
 
 
-class HerokuServer(FastAPIServer):
+class HerokuServer(Server):
     """Special FastAPI server to pickup port from env PORT"""
 
     type: ClassVar = "_heroku"
+    server: Server
+
+    @validator("server")
+    @classmethod
+    def server_validator(cls, value: Server):
+        if value.port_field is None:
+            raise ValueError(
+                f"{value} does not have port field and can not be exposed on heroku"
+            )
+        return value
 
     def serve(self, interface: Interface):
-        self.port = int(os.environ["PORT"])
-        logger.info("Switching port to %s", self.port)
-        return super().serve(interface)
+        assert self.server.port_field is not None  # ensured by validator
+        setattr(self.server, self.server.port_field, int(os.environ["PORT"]))
+        logger.info(
+            "Switching port to %s",
+            getattr(self.server, self.server.port_field),
+        )
+        return self.server.serve(interface)

--- a/mlem/contrib/heroku/server.py
+++ b/mlem/contrib/heroku/server.py
@@ -1,9 +1,10 @@
 import logging
 import os
-from typing import ClassVar
+from typing import ClassVar, Dict
 
 from pydantic import validator
 
+from mlem.core.requirements import Requirements
 from mlem.runtime import Interface
 from mlem.runtime.server import Server
 
@@ -33,3 +34,14 @@ class HerokuServer(Server):
             getattr(self.server, self.server.port_field),
         )
         return self.server.serve(interface)
+
+    def get_requirements(self) -> Requirements:
+        return self.server.get_requirements()
+
+    def get_env_vars(self) -> Dict[str, str]:
+        env_vars = super().get_env_vars()
+        env_vars.update(self.server.get_env_vars())
+        return env_vars
+
+    def get_sources(self) -> Dict[str, bytes]:
+        return self.server.get_sources()

--- a/mlem/contrib/streamlit/server.py
+++ b/mlem/contrib/streamlit/server.py
@@ -5,7 +5,7 @@ import subprocess
 import tempfile
 from threading import Thread
 from time import sleep
-from typing import ClassVar, Dict, Optional
+from typing import ClassVar, Dict, List, Optional
 
 import streamlit
 import streamlit_pydantic
@@ -52,6 +52,7 @@ class StreamlitServer(Server, StreamlitScript, LibRequirementsMixin):
 
     type: ClassVar = "streamlit"
     libraries: ClassVar = (streamlit, streamlit_pydantic)
+    port_field: ClassVar = "ui_port"
 
     run_server: bool = True
     """Whether to run backend server or use existing one"""
@@ -159,3 +160,6 @@ class StreamlitServer(Server, StreamlitScript, LibRequirementsMixin):
                 sources[template] = f.read()
             self.template = template
         return sources
+
+    def get_ports(self) -> List[int]:
+        return [self.ui_port, self.server_port]

--- a/mlem/runtime/server.py
+++ b/mlem/runtime/server.py
@@ -118,6 +118,7 @@ class Server(MlemABC, ABC, WithRequirements, _ServerOptions):
     abs_name: ClassVar[str] = "server"
     env_vars: ClassVar[Optional[Dict[str, str]]] = None
     additional_source_files: ClassVar[Optional[List[str]]] = None
+    port_field: ClassVar[Optional[str]] = None
 
     # @validator("interface")
     # @classmethod
@@ -157,6 +158,11 @@ class Server(MlemABC, ABC, WithRequirements, _ServerOptions):
         return super().get_requirements() + get_object_requirements(
             [self.request_serializer, self.response_serializer, self.methods]
         )
+
+    def get_ports(self) -> List[int]:
+        if self.port_field is not None:
+            return [getattr(self, self.port_field)]
+        return []
 
 
 class ServerInterface(Interface):


### PR DESCRIPTION
closes #568

Heroku requires you to use `PORT` env to expose a port.
I changed `HerokuServer` to wrap arbitrary server (instead of subclassing `FastAPIServer`) and swap port for value from env. For that it needs to know which value is to swap, so I added `port_field` classvar to servers.