### PR TITLE
Workaround for dill IndexError

### DIFF
--- a/mlem/utils/module.py
+++ b/mlem/utils/module.py
@@ -454,7 +454,7 @@ def add_closure_inspection(f):
         try:
             try:
                 source = dill.source.getsource(obj)
-            except OSError:
+            except (OSError, IndexError):
                 source = inspect.getsource(obj)
             tree = ast.parse(lstrip_lines(source))
             ImportFromVisitor(pickler, obj).visit(tree)


### PR DESCRIPTION
With new sklearn version, some methods of custom class implementations are wrapped with some sklearn magic (see `sklearn.utils._SetOutputMixin`). This breaks `getsource` function from `dill.sources` which we use to get object source code.

related https://github.com/uqfoundation/dill/issues/581 closes #623