### PR TITLE
Allow to force deploy if deploy parameters change

### DIFF
--- a/mlem/core/objects.py
+++ b/mlem/core/objects.py
@@ -1277,6 +1277,10 @@ class MlemDeployment(MlemObject, Generic[ST, ET]):
             self, self.state_type
         ) or self.state_type(declaration=self)
 
+    @property
+    def is_state_empty(self):
+        return self._state_manager.get_state(self, self.state_type) is None
+
     def lock_state(self):
         return self._state_manager.lock_state(self)
 


### PR DESCRIPTION
Adds `--force` flag to deploy cli command. If deployment parameters changed and this flag set, mlem will remove old deployment and create new one.
Also, now there will be no error if parameters changed, but old app does not have state

Limitations:
* for now only available from cli since adding this to API required a bit of refactoring
* deployment will always be re-created even if platform allows to just update old deployment

related #463
closes #549