### PR TITLE
Allow to set ENV vars for `build docker` and `deploy kubernetes`

### DIFF
--- a/mlem/contrib/docker/base.py
+++ b/mlem/contrib/docker/base.py
@@ -27,7 +27,7 @@ from mlem.config import LOCAL_CONFIG, project_config
 from mlem.contrib.docker.context import (
     DockerBuildArgs,
     DockerModelDirectory,
-    get_build_args,
+    parse_envs,
 )
 from mlem.contrib.docker.utils import (
     build_image_with_logs,
@@ -596,7 +596,7 @@ class DockerImageBuilder(MlemBuilder, _DockerBuildMixin):
                     tag=tag,
                     rm=True,
                     platform=self.args.platform,
-                    buildargs=get_build_args(self.args.build_arg),
+                    buildargs=parse_envs(self.args.build_arg),
                 )
                 docker_image = DockerImage(**self.image.dict())
                 docker_image.image_id = image.id

--- a/mlem/contrib/kubernetes/base.py
+++ b/mlem/contrib/kubernetes/base.py
@@ -79,7 +79,9 @@ class K8sDeployment(
     templates_dir: List[str] = []
     """List of dirs where templates reside"""
     build_arg: List[str] = []
-    """Args to use at build time https://docs.docker.com/engine/reference/commandline/build/#build-arg"""
+    """ARG vars to use at build time https://docs.docker.com/engine/reference/commandline/build/#build-arg"""
+    set_env: List[str] = []
+    """ENV vars to set in the image https://docs.docker.com/engine/reference/builder/#env"""
 
     def load_kube_config(self):
         config.load_kube_config(
@@ -137,6 +139,7 @@ class K8sDeployment(
                     daemon=self.daemon,
                     server=self.get_server(),
                     build_arg=self.build_arg,
+                    set_env=self.set_env,
                 )
                 state.update_model(model)
                 redeploy = True

--- a/mlem/contrib/kubernetes/build.py
+++ b/mlem/contrib/kubernetes/build.py
@@ -17,6 +17,7 @@ def build_k8s_docker(
     platform: Optional[str] = "linux/amd64",
     # runners usually do not support arm64 images built on Mac M1 devices
     build_arg: Optional[List[str]] = None,
+    set_env: Optional[List[str]] = None,
 ):
     echo(EMOJI_BUILD + f"Creating docker image {image_name}")
     with set_offset(2):
@@ -30,4 +31,5 @@ def build_k8s_docker(
             force_overwrite=True,
             platform=platform,
             build_arg=build_arg or [],
+            set_env=set_env or [],
         )

--- a/mlem/core/errors.py
+++ b/mlem/core/errors.py
@@ -178,3 +178,11 @@ class ExtensionRequirementError(MlemError, ImportError):
         super().__init__(
             f"Extension '{ext}' requires additional dependencies: {extra_install}`pip install {reqs_str}`"
         )
+
+
+class EnvVarNotSet(MlemError):
+    def __init__(self, name: str):
+        self.name = name
+        super().__init__(
+            f'"{name}" was supposed to be read from shell/env vars, but was not found there'
+        )


### PR DESCRIPTION
this is for https://github.com/iterative/mlem/issues/647#issuecomment-1486339710

This work similarly to https://github.com/iterative/mlem/pull/645:

`mlem build docker` works the same, but I'll provide an example for k8s deploy here:

```
$ mlem declare deployment kubernetes deployer \
  --image_name myimage --service_type loadbalancer --registry remote \
  --env docker --env.registry remote --registry.host localhost --namespace myns \
  --set_env.0 VAR1 --set_env.1 VAR2=aguschin
💾 Saving deployment to deployer.mlem
```

```yaml
# deployer.mlem
env:
  object_type: env
  registry:
    type: remote
  type: kubernetes
image_name: myimage
namespace: myns
object_type: deployment
registry:
  host: localhost
  type: remote
service_type:
  type: loadbalancer
set_env:
- VAR1
- VAR2=aguschin
type: kubernetes
```

Then in Dockerfile for your image you'll get:
```
...
ENV VAR1=VALUE1
ENV VAR2=aguschin
```

`VALUE1` will be taken from shell/env vars with `os.getenv("VAR1")`. If it's not set, an Exception will be raised by MLEM.