### PR TITLE
Make MLEM work with flyctl 0.1.x

### DIFF
--- a/mlem/cli/deployment.py
+++ b/mlem/cli/deployment.py
@@ -145,7 +145,9 @@ def create_deploy_run_command(type_name):
                 if not meta.is_state_empty:
                     if not force:
                         raise DeploymentError(
-                            f"Different deployment meta already exists at {meta.loc}. Please use `mlem deployment run --load <path> ...`"
+                            f"The deployment file you specified ('{meta.loc.basename}') already describes a different deployment."
+                            " Please add `--force` to overwrite it,"
+                            " or use `mlem deployment run --load <path> ...` to reuse it."
                         )
                     echo(
                         EMOJI_STOP

--- a/tests/contrib/test_flyio.py
+++ b/tests/contrib/test_flyio.py
@@ -2,7 +2,15 @@ from pathlib import Path
 from unittest.mock import ANY, patch
 
 from mlem.contrib.flyio.meta import FlyioApp
-from mlem.contrib.flyio.utils import FlyioStatusModel
+from mlem.contrib.flyio.utils import FlyioStatusModel, check_flyctl_exec
+
+
+def test_check_flyctl_exec():
+    output = check_flyctl_exec()
+    version = output["Version"]
+    assert (
+        version.split(".")[1] == "1"
+    ), f"flyctl version was bumped ({version} now), this may cause problems with deployment"
 
 
 def test_flyio_create_app(tmp_path: Path):


### PR DESCRIPTION
- [x] warn to update flyctl at cmd runs, add tests
- [ ] make MLEM work with flyctl 0.1.x. Check fastapi and streamlit deployments. #574 may help replace manual tests with automated ones here.
- [ ] as follow-up: check why deployment of `params: Dict[str, Any]` breaks for fly. Was introduced in #670 

close #677 