### PR TITLE
Expose GTO version in FastAPI's interface

### DIFF
--- a/mlem/contrib/sklearn.py
+++ b/mlem/contrib/sklearn.py
@@ -103,6 +103,11 @@ class SklearnPipelineType(SklearnModel):
         methods_sample_data: Optional[Dict[str, Any]] = None,
         **kwargs
     ) -> ModelType:
+        if not hasattr(obj, "predict"):
+            # assuming the Pipeline has only transform steps
+            return SklearnTransformer.process(
+                obj, sample_data, methods_sample_data, **kwargs
+            )
         methods_sample_data = methods_sample_data or {}
         mt = SklearnPipelineType(io=SimplePickleIO(), methods={}).bind(obj)
         predict = obj.predict

--- a/mlem/core/registry.py
+++ b/mlem/core/registry.py
@@ -1,0 +1,26 @@
+from abc import ABC
+from typing import ClassVar
+
+from mlem.core.base import MlemABC
+
+
+class ArtifactInRegistry(MlemABC, ABC):
+    """Artifact registered within an Artifact Registry.
+    Can provide version and stage it's promoted to.
+    """
+
+    class Config:
+        type_root = True
+        default_type = "gto"
+
+    abs_name: ClassVar = "artifact_in_registry"
+    uri: str
+    """location"""
+
+    @property
+    def version(self):
+        raise NotImplementedError
+
+    @property
+    def stage(self):
+        raise NotImplementedError

--- a/mlem/runtime/server.py
+++ b/mlem/runtime/server.py
@@ -338,3 +338,6 @@ class ServerInterface(Interface):
 
     def get_model_meta(self):
         return getattr(getattr(self.interface, "model", None), "params", None)
+
+    def get_model_version(self):
+        return self.interface.model_version

--- a/mlem/utils/module.py
+++ b/mlem/utils/module.py
@@ -565,6 +565,12 @@ class RequirementAnalyzer(dill.Pickler):
         )
 
     def add_requirement(self, obj_or_module):
+        # if callable(obj_or_module):
+        # from sklearn.preprocessing import FunctionTransformer
+        # from sklearn.pipeline import Pipeline
+        # if isinstance(obj_or_module, Pipeline):
+        #     import ipdb; ipdb.set_trace()
+
         if not isinstance(obj_or_module, ModuleType):
             try:
                 module = get_object_module(obj_or_module)


### PR DESCRIPTION
close #665 

If you do:

```sh
git clone https://github.com/iterative/example-gto
cd example-gto
git checkout mlem
mlem --tb serve fastapi -m models/churn.pkl
```

You'll see model version on the last line:

<img width="1081" alt="image" src="https://github.com/iterative/mlem/assets/6797716/58a3c1fb-351c-420f-95e3-e04a74d6dc23">

TODO:
- [ ] add tests
- [ ] rename "version" to "mlem_version"
- [ ] review implementation - rough and needs to be refined