### PR TITLE
CI fix - Try to free up space

### DIFF
--- a/.github/workflows/check-test-release.yml
+++ b/.github/workflows/check-test-release.yml
@@ -36,6 +36,8 @@ jobs:
       with:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha || github.ref }}
+    - name: Freeing up disk space
+      run: "${GITHUB_WORKSPACE}/hack/scripts/ci/free-space.sh"
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x'

--- a/hack/scripts/ci/free-space.sh
+++ b/hack/scripts/ci/free-space.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env sh
+# Copyright 2023 The Nuclio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+print_free_space() {
+  df --human-readable
+}
+
+# before cleanup
+print_free_space
+
+# clean unneeded os packages and misc
+sudo apt-get remove -y '^dotnet-.*'
+sudo apt-get remove -y 'php.*'
+sudo apt-get remove -y \
+  azure-cli \
+  google-cloud-sdk \
+  google-chrome-stable \
+  firefox \
+  powershell
+
+sudo apt-get autoremove --yes
+sudo apt clean
+
+# cleanup unneeded share dirs ~30GB
+sudo rm --recursive --force \
+    /usr/local/lib/android \
+    /usr/share/dotnet \
+    /usr/share/miniconda \
+    /usr/share/swift
+
+# clean unneeded docker images
+docker system prune --all --force
+
+# post cleanup
+print_free_space


### PR DESCRIPTION
Recent CI runs fail on disk space being exhausted on X
example: https://github.com/iterative/mlem/actions/runs/5547778758/jobs/10130001551?pr=694

Failure:
```bash
...
ERROR: Could not install packages due to an OSError: [Errno 28] No space left on device
```
Bringing over a hack we discover years ago in [nuclio](https://github.com/nuclio/nuclio) to clear disk space. 🤞 