### PR TITLE
Larger runners for CI

### DIFF
--- a/.github/workflows/check-test-release.yml
+++ b/.github/workflows/check-test-release.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest-8-cores, windows-latest, macos-latest]
         python: ["3.8", "3.9", "3.10"]
         exclude:
         # no HDF5 support installed for tables


### PR DESCRIPTION
300Gb disk
Because there's a repeating out of disk space errors in CI