### PR TITLE
Migrate from PyPI tokens to Trusted Publishers

### DIFF
--- a/.github/workflows/check-test-release.yml
+++ b/.github/workflows/check-test-release.yml
@@ -131,12 +131,12 @@ jobs:
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
   deploy:
+    name: PyPI Deploy
+    needs: [check, test]
     environment: pypi
     permissions:
       contents: write
       id-token: write
-    name: PyPI Deploy
-    needs: [check, test]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/check-test-release.yml
+++ b/.github/workflows/check-test-release.yml
@@ -131,6 +131,10 @@ jobs:
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
   deploy:
+    environment: pypi
+    permissions:
+      contents: write
+      id-token: write
     name: PyPI Deploy
     needs: [check, test]
     runs-on: ubuntu-latest
@@ -146,8 +150,9 @@ jobs:
       uses: casperdcl/deploy-pypi@v2
       with:
         build: true
-        password: ${{ secrets.PYPI_TOKEN }}
-        upload: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }}
+        upload: false
+    - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@release/v1
     - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       name: Release
       run: |


### PR DESCRIPTION
https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers#using-trusted-publishing-with-github-actions